### PR TITLE
Style journal citations on trajectory cards

### DIFF
--- a/src/components/ModelCard/index.tsx
+++ b/src/components/ModelCard/index.tsx
@@ -51,8 +51,18 @@ const ModelCard: React.FunctionComponent<ModelCardProps> = (
                     <p className={styles.cardTitle}>{title.toUpperCase()}</p>
                 </Link>
                 <p>{authors}</p>
-                <a href={publication.url}>
-                    <p>{publication.title}</p>
+                <a
+                    href={publication.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    <p className={styles.publication}>
+                        {publication.title}.{" "}
+                        <span className={styles.journal}>
+                            {publication.journal}{" "}
+                        </span>
+                        ({publication.year})
+                    </p>
                 </a>
                 <p>{description}</p>
             </div>

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -29,6 +29,14 @@ p {
     font-weight: 600;
 }
 
+.publication {
+    font-size: 14px;
+}
+
+.journal {
+    font-style: italic;
+}
+
 a, a :hover {
     color: var(--landing-pg-card-link-gray);
     transition: none;

--- a/src/constants/interfaces.ts
+++ b/src/constants/interfaces.ts
@@ -6,6 +6,8 @@ export interface TrajectoryDisplayData {
     authors: string;
     publication: {
         title: string;
+        journal: string;
+        year: number;
         url: string;
     };
     description: string;

--- a/src/constants/networked-trajectories.ts
+++ b/src/constants/networked-trajectories.ts
@@ -14,7 +14,9 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
         authors: "Jonathan Alberts et al",
         publication: {
             title:
-                "In Silico Reconstitution of Listeria Propulsion Exhibits Nano-Saltation. PLoS Biology 2004.",
+                "In Silico Reconstitution of Listeria Propulsion Exhibits Nano-Saltation",
+            journal: "PLoS Biology",
+            year: 2004,
             url:
                 "https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.0020412",
         },
@@ -30,7 +32,9 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
         authors: "Susanne Rafelski et al",
         publication: {
             title:
-                "An Experimental and Computational Study of the Effect of ActA Polarity on the Speed of Listeria monocytogenes Actin-based Motility. PLoS Comp. Biology 2009.",
+                "An Experimental and Computational Study of the Effect of ActA Polarity on the Speed of Listeria monocytogenes Actin-based Motility",
+            journal: "PLoS Comp. Biology",
+            year: 2009,
             url:
                 "https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1000434",
         },
@@ -46,7 +50,9 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
         authors: "Matthew Akamatsu et al",
         publication: {
             title:
-                "Principles of self-organization and load adaptation by the actin cytoskeleton during clathrin-mediated endocytosis. eLife 2020.",
+                "Principles of self-organization and load adaptation by the actin cytoskeleton during clathrin-mediated endocytosis",
+            journal: "eLife",
+            year: 2020,
             url: "https://elifesciences.org/articles/49840",
         },
         description:
@@ -61,7 +67,9 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
         authors: "Ngan Nguyen et al",
         publication: {
             title:
-                "Modeling in the Time of COVID-19: Statistical and Rule-based Mesoscale Models. arXiv 2020.",
+                "Modeling in the Time of COVID-19: Statistical and Rule-based Mesoscale Models",
+            journal: "arXiv",
+            year: 2020,
             url: "https://arxiv.org/abs/2005.01804",
         },
         description:


### PR DESCRIPTION
Resolves issue: https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-988#

- Made the journal citations on the landing page's trajectory cards smaller and formatted.
- While I was at it, I also made the link to the journal article open the article in a new tab.

Some other styling changes that affect these trajectory cards' contents are pending review in the [tutorial page PR](https://github.com/allen-cell-animated/simularium-website/pull/20) -- namely just that the links will be colored blue.

Before:
![image](https://user-images.githubusercontent.com/12690133/93834024-4e90db00-fc2f-11ea-8f18-2e71cf848cfa.png)

After:
![image](https://user-images.githubusercontent.com/12690133/93833987-315c0c80-fc2f-11ea-996b-23e4ead4f75e.png)

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
