### PR TITLE
Add small screen warning for viewer page

### DIFF
--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -66,9 +66,9 @@ class App extends React.Component<AppProps, AppState> {
     componentDidMount() {
         if (window.matchMedia("(max-width: 900px)").matches) {
             Modal.warning({
-                title: "Mobile devices are not supported",
+                title: "Small screens are not supported",
                 content:
-                    "The Simularium Viewer does not support mobile devices at this time. Please try on a computer for the best experience.",
+                    "The Simularium Viewer does not support small screens at this time. Please use a larger screen for the best experience.",
             });
         }
 


### PR DESCRIPTION
Resolves issue: https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1005

Displays a warning when someone tries to access the viewer from a mobile device. When the user taps on "OK" the warning is dismissed and the user can proceed to the viewer (although it won't work well if at all).

There are no mockups that I went by, so any wording or style suggestions are welcome. 

Portrait mode:
<img width="837" alt="Screen Shot 2020-09-29 at 1 42 19 PM" src="https://user-images.githubusercontent.com/12690133/94614793-94ffbe80-025b-11eb-9a87-34dba9e4a378.png">

Landscape mode:
<img width="837" alt="Screen Shot 2020-09-29 at 1 41 50 PM" src="https://user-images.githubusercontent.com/12690133/94614801-97faaf00-025b-11eb-94c6-6d37a12a3e90.png">



**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
