### PR TITLE
staging autodeploy should use staging backend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,6 +111,9 @@ pipeline {
                 branch "master"
                 equals expected: BUILD_ARTIFACT, actual: params.JOB_TYPE
             }
+            environment {
+                DEPLOYMENT_ENV = "staging"
+            }
             steps {
                 script {
                     DEPLOYMENT_TYPE = STAGING_DEPLOYMENT


### PR DESCRIPTION
I'm going to do the changes here piecemeal since the only way I know to test if it worked is to actually have it run on jenkins. 

This *should* make it so the auto deploy on staging uses the staging backend. 

**Pull request recommendations:**

- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [ ] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
