### PR TITLE
Fix/staging production builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                 equals expected: BUILD_ARTIFACT, actual: params.JOB_TYPE
             }
             environment {
-                DEPLOYMENT_ENV = "staging"
+                DEPLOYMENT_ENV = STAGING_DEPLOYMENT
             }
             steps {
                 sh "./gradlew -i snapshotPublishTarGzAndDockerImage"


### PR DESCRIPTION
Goals: 
1. Auto deploy of master to staging uses "staging" as the build variable
2. Deployment through the Jenkins interface is a one step process where the build type can be either "staging" or "production" but defaults to "production".

Question: 
1. What does "promote" do? Why do I need to trigger it through the Jenkins interface when deploying, but the auto deploy master doesn't seem to use it. Do I need to trigger it on DEPLOY_ARTIFACT too if I want this to be a 1 step process? *UPDATE: I have promote run if DEPLOYMENT_TYPE === "production" and JOB_TYPE === DEPLOY_ARTIFACT. Let me know if that's not what should happen. 

**Pull request recommendations:**

- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [ ] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
