### PR TITLE
try not running promote

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,15 +112,15 @@ pipeline {
             }
         }
 
-        stage ("promote") {
-            when {
-                equals expected: PRODUCTION_DEPLOYMENT, actual: params.DEPLOYMENT_TYPE
-                equals expected: DEPLOY_ARTIFACT, actual: params.JOB_TYPE
-            }
-            steps {
-                sh "${PYTHON} ${VENV_BIN}/promote_artifact -t maven -g ${params.GIT_TAG}"
-            }
-        }
+        // stage ("promote") {
+        //     when {
+        //         equals expected: PRODUCTION_DEPLOYMENT, actual: params.DEPLOYMENT_TYPE
+        //         equals expected: DEPLOY_ARTIFACT, actual: params.JOB_TYPE
+        //     }
+        //     steps {
+        //         sh "${PYTHON} ${VENV_BIN}/promote_artifact -t maven -g ${params.GIT_TAG}"
+        //     }
+        // }
 
         stage("automated deploy") {
             when {


### PR DESCRIPTION
I just ran "DEPLOY" with "production" but what ended up in the production bucket is still connecting to the `staging` backend. Reading through the logs, I *think* what might be happening is the production build is building and being put in the `maven-release-local` but "promote" is copying what is in `maven-snapshot-local` (the staging build) into `maven-release-local`. So I want to try this without the promote stage. 

**Pull request recommendations:**

- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [ ] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
