### PR TITLE
Fix/playback buttons not showing spinner when loading or buttons freezing when scrubbing

### DIFF
--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -173,8 +173,12 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     }
 
     public startPlay() {
-        const { time, simulariumController } = this.props;
-        simulariumController.playFromTime(time);
+        const { time, timeStep, simulariumController, totalTime } = this.props;
+        let newTime = time;
+        if (newTime + timeStep >= totalTime) {
+            newTime = 0;
+        }
+        simulariumController.playFromTime(newTime);
         simulariumController.resume();
         this.setState({ requestingTimeChange: true, isPlaying: true });
     }


### PR DESCRIPTION
Resolves:
* [Playback buttons get stuck as spinners when user scrubs back to beginning of simulation](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1162)
* [Playback controls don't turn into spinners when frames are being loaded](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1140)

Sorry to lump these 2 tickets together but they seem to be closely related bugs.

Previously, when a user would hit play, the simulation would advance 1 frame forward and then hang, waiting for the rest of the data to arrive. 

Now, when the user hits play, the simulation does not advance 1 frame forward before hanging. And, while it's hanging and waiting for data to arrive, it shows the playback buttons as loading spinners.

Just adding `this.setState({ requestingTimeChange: true });` to `startPlay()` didn't fix the spinner issue because the spinners disappeared as soon as the simulation advanced the 1 frame forward. Preventing the simulation from advancing 1 frame upon hitting Play _and_ adding `this.setState({ requestingTimeChange: true });` was necessary to fix the issue.

The changes in this PR seem to have resolved the playback buttons getting stuck in a loading (spinner) state upon scrubbing as well.


**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
