### PR TITLE
fix/time unit not updating in total time

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -54,17 +54,17 @@ const PlayBackControls = ({
         lastFrameTime can divide by 1000. Math.log(x) / Math.log(1000) is the same as log base 1000 of x:
         https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log/#Examples
         */
-        let unitIndex = Math.ceil(Math.log(1 / lastFrameTime) / Math.log(1000));
+        let index = Math.ceil(Math.log(1 / lastFrameTime) / Math.log(1000));
 
         // Handle very small values (use ns if lastFrameTime is less than 1 ns)
-        if (unitIndex >= units.length) {
-            unitIndex = units.length - 1;
+        if (index >= units.length) {
+            index = units.length - 1;
             // Handle very large values (use s if lastFrameTime is greater than 1000 s)
-        } else if (unitIndex < 0) {
-            unitIndex = 0;
+        } else if (index < 0) {
+            index = 0;
         }
 
-        setUnitIndex(unitIndex);
+        setUnitIndex(index);
     }, [lastFrameTime]);
 
     const btnClassNames = classNames([styles.item, styles.btn]);


### PR DESCRIPTION
While I was testing with a trajectory in nanosecond-scale I noticed the unit in the total time wasn't updating -- it's because I was using a regular variable `unitIndex` instead of creating a local state for it. React 101. Let me know if you want test data and I'll send it to you.

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
