### PR TITLE
Fix/"Load an example instead" link in left panel of empty viewer

### DIFF
--- a/src/containers/ModelPanel/index.tsx
+++ b/src/containers/ModelPanel/index.tsx
@@ -43,7 +43,10 @@ import {
 } from "../../state/metadata/constants";
 import NoTrajectoriesText from "../../components/NoTrajectoriesText";
 import NoTypeMappingText from "../../components/NoTrajectoriesText/NoTypeMappingText";
-import { ViewerStatus } from "../../state/metadata/types";
+import {
+    ViewerStatus,
+    RequestNetworkFileAction,
+} from "../../state/metadata/types";
 import NetworkFileFailedText from "../../components/NoTrajectoriesText/NetworkFileFailedText";
 
 const styles = require("./style.css");
@@ -63,6 +66,7 @@ interface ModelPanelProps {
     agentColors: AgentColorMap;
     viewerStatus: ViewerStatus;
     isNetworkedFile: boolean;
+    changeToNetworkedFile: ActionCreator<RequestNetworkFileAction>;
 }
 
 class ModelPanel extends React.Component<ModelPanelProps, {}> {
@@ -80,6 +84,7 @@ class ModelPanel extends React.Component<ModelPanelProps, {}> {
             agentColors,
             viewerStatus,
             isNetworkedFile,
+            changeToNetworkedFile: loadNetworkFile,
         } = this.props;
         const checkboxTree = (
             <CheckBoxTree
@@ -97,9 +102,7 @@ class ModelPanel extends React.Component<ModelPanelProps, {}> {
         );
         const contentMap = {
             [VIEWER_SUCCESS]: checkboxTree,
-            [VIEWER_EMPTY]: (
-                <NoTrajectoriesText selectFile={changeToNetworkedFile} />
-            ),
+            [VIEWER_EMPTY]: <NoTrajectoriesText selectFile={loadNetworkFile} />,
             [VIEWER_LOADING]: <div />,
             [VIEWER_ERROR]: isNetworkedFile ? (
                 <NetworkFileFailedText />


### PR DESCRIPTION
Resolves: ["Load an example instead" link in empty viewer left panel doesn't work](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1218)

Super weird, I remember struggling with this problem when I first added this feature and Megan helped me figure out this (passing in `changeToNetworkedFile` as a prop to `ModelPanel` instead of using the imported action directly) was the solution. Apparently it never got merged properly. Maybe I accidentally removed some changes while fixing a merge conflict or something.

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
