### PR TITLE
Feature/Save lastFrameTime as metadata only after first frame loads

### DIFF
--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -56,6 +56,7 @@ interface ViewerPanelProps {
     receiveAgentTypeIds: ActionCreator<ReceiveAction>;
     firstFrameTime: number;
     lastFrameTime: number;
+    numFrames: number;
     receiveMetadata: ActionCreator<ReceiveAction>;
     receiveAgentNamesAndStates: ActionCreator<ReceiveAction>;
     selectionStateInfoForViewer: SelectionStateInfo;
@@ -257,10 +258,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         });
 
         receiveMetadata({
-            // lastFrameTime here is incomplete until we receive the timestamp for the
-            // first frame in receiveTimeChange() later.
-            // data.totalSteps is a misnomer; it is actually the total number of frames.
-            lastFrameTime: (data.totalSteps - 1) * data.timeStepSize,
+            numFrames: data.totalSteps,
             timeStepSize: data.timeStepSize,
         });
     }
@@ -271,6 +269,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             setViewerStatus,
             viewerStatus,
             lastFrameTime,
+            numFrames,
             timeStep,
             receiveMetadata,
         } = this.props;
@@ -278,9 +277,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         if (this.state.isInitialPlay) {
             receiveMetadata({
                 firstFrameTime: timeData.time,
-                // Now that we have the timestamp for the first frame, use it to calculate
-                // the real lastFrameTime
-                lastFrameTime: timeData.time + lastFrameTime,
+                lastFrameTime: (numFrames - 1) * timeStep + timeData.time,
             });
             this.setState({ isInitialPlay: false });
         }
@@ -410,6 +407,7 @@ function mapStateToProps(state: State) {
         lastFrameTime: metadataStateBranch.selectors.getLastFrameTimeOfCachedSimulation(
             state
         ),
+        numFrames: metadataStateBranch.selectors.getNumFrames(state),
         timeStep: metadataStateBranch.selectors.getTimeStepSize(state),
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),
         viewerStatus: metadataStateBranch.selectors.getViewerStatus(state),

--- a/src/state/metadata/selectors.ts
+++ b/src/state/metadata/selectors.ts
@@ -18,6 +18,7 @@ export const getFirstFrameTimeOfCachedSimulation = (state: State) =>
     state.metadata.firstFrameTime;
 export const getLastFrameTimeOfCachedSimulation = (state: State) =>
     state.metadata.lastFrameTime;
+export const getNumFrames = (state: State) => state.metadata.numFrames;
 export const getTimeStepSize = (state: State) => state.metadata.timeStepSize;
 export const getAgentIds = (state: State) => state.metadata.agentIds;
 export const getSimulariumFile = (state: State) =>


### PR DESCRIPTION
Resolves: [Save lastFrameTime as metadata only when we have all necessary data](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1229)

Thanks Megan for this suggestion.

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
