### PR TITLE
Fix/remove scientific notation from playback time

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -40,7 +40,7 @@ const PlayBackControls = ({
     const [unitIndex, setUnitIndex] = useState(0);
 
     const units = ["s", "ms", "\u03BCs", "ns"];
-    const roundNumber = (num: number) => Number(num).toPrecision(3);
+    const roundNumber = (num: number) => parseFloat(Number(num).toPrecision(3));
     const roundedTime = time ? roundNumber(time * 1000 ** unitIndex) : 0;
     const roundedLastFrameTime = roundNumber(lastFrameTime * 1000 ** unitIndex);
 


### PR DESCRIPTION
It's more readable now.

COVID (used to read `8.64e+4 s` for total time, for example):
![image](https://user-images.githubusercontent.com/12690133/101960958-7c961380-3bbd-11eb-894f-5e6ca5dc7e43.png)

Someday we'll put it in HH:MM format.

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
