### PR TITLE
Fix/nav bar overflowing when title is long

### DIFF
--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useLocation } from "react-router-dom";
-import { Tag } from "antd";
+import { Tag, Popover } from "antd";
 import moment from "moment";
 
 import { VIEWER_PATHNAME } from "../../routes";
@@ -55,11 +55,15 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
             <span />
         );
 
+    const popover = title;
+
     return (
-        <div className={styles.container}>
-            <div className={styles.title}>{title}</div>
-            <div>{tag}</div>
-        </div>
+        <Popover content={popover}>
+            <div className={styles.container}>
+                <div className={styles.title}>{title}</div>
+                <div>{tag}</div>
+            </div>
+        </Popover>
     );
 };
 

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -19,11 +19,9 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
     const { simulariumFileName, lastModified } = props;
     const location = useLocation();
     const title =
-        location.pathname.startsWith(VIEWER_PATHNAME) && simulariumFileName ? (
-            <span>{simulariumFileName}</span>
-        ) : (
-            <span />
-        );
+        location.pathname.startsWith(VIEWER_PATHNAME) && simulariumFileName
+            ? simulariumFileName
+            : "";
 
     // Grab the trajectory ID from the URL and find the corresponding trajectory object in
     // networked-trajectories.ts to get its version info
@@ -58,9 +56,10 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
         );
 
     return (
-        <span className={styles.container}>
-            {title} {tag}
-        </span>
+        <div className={styles.container}>
+            <div className={styles.title}>{title}</div>
+            <div>{tag}</div>
+        </div>
     );
 };
 

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -57,7 +57,7 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
 
     return (
         <div className={styles.container}>
-            <Popover content={title} mouseLeaveDelay={0}>
+            <Popover content={title} mouseEnterDelay={1} mouseLeaveDelay={0}>
                 <div className={styles.title}>{title}</div>
             </Popover>
             <div>{tag}</div>

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -55,15 +55,13 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
             <span />
         );
 
-    const popover = title;
-
     return (
-        <Popover content={popover}>
-            <div className={styles.container}>
+        <div className={styles.container}>
+            <Popover content={title}>
                 <div className={styles.title}>{title}</div>
-                <div>{tag}</div>
-            </div>
-        </Popover>
+            </Popover>
+            <div>{tag}</div>
+        </div>
     );
 };
 

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -57,7 +57,14 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
 
     return (
         <div className={styles.container}>
-            <Popover content={title} mouseEnterDelay={1} mouseLeaveDelay={0}>
+            <Popover
+                content={title}
+                mouseEnterDelay={1}
+                mouseLeaveDelay={0}
+                align={{
+                    offset: [0, 10],
+                }}
+            >
                 <div className={styles.title}>{title}</div>
             </Popover>
             <div>{tag}</div>

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -57,7 +57,7 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
 
     return (
         <div className={styles.container}>
-            <Popover content={title}>
+            <Popover content={title} mouseLeaveDelay={0}>
                 <div className={styles.title}>{title}</div>
             </Popover>
             <div>{tag}</div>

--- a/src/components/ViewerTitle/style.css
+++ b/src/components/ViewerTitle/style.css
@@ -2,7 +2,15 @@
     text-align: center;
     font-size: 16px;
     font-weight: 400;
-    display: block;
+    display: flex;
+    text-overflow: ellipsis;
+    max-width: calc(100vw - 562px);
+}
+
+.title {
+    /* white-space: nowrap; */
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .tag {

--- a/src/components/ViewerTitle/style.css
+++ b/src/components/ViewerTitle/style.css
@@ -3,11 +3,13 @@
     font-size: 16px;
     font-weight: 400;
     display: flex;
-    text-overflow: ellipsis;
     max-width: calc(100vw - 562px);
 }
 
 .title {
+    /* FIXME: if I turn this on, the ellipses show but the buttons on the
+    right get pushed out more easily. Without tag in the nav bar and
+    without this whitespace nowrap, things behave well. */
     /* white-space: nowrap; */
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/ViewerTitle/style.css
+++ b/src/components/ViewerTitle/style.css
@@ -4,13 +4,11 @@
     font-weight: 400;
     display: flex;
     max-width: calc(100vw - 562px);
+    min-width: 0;
 }
 
 .title {
-    /* FIXME: if I turn this on, the ellipses show but the buttons on the
-    right get pushed out more easily. Without tag in the nav bar and
-    without this whitespace nowrap, things behave well. */
-    /* white-space: nowrap; */
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }

--- a/src/containers/AppHeader/index.tsx
+++ b/src/containers/AppHeader/index.tsx
@@ -58,7 +58,7 @@ class AppHeader extends React.Component<AppHeaderProps, {}> {
 
         return (
             <div className={styles.pageHeader}>
-                <div>
+                <div className={styles.leftLinks}>
                     <a href="https://allencell.org" title="Allen Cell Explorer">
                         {AicsLogo}
                     </a>

--- a/src/containers/AppHeader/index.tsx
+++ b/src/containers/AppHeader/index.tsx
@@ -67,12 +67,10 @@ class AppHeader extends React.Component<AppHeaderProps, {}> {
                         SIMULARIUM HOME
                     </Link>
                 </div>
-                <div className={styles.viewerTitle}>
-                    <ViewerTitle
-                        simulariumFileName={displayName}
-                        lastModified={lastModified}
-                    />
-                </div>
+                <ViewerTitle
+                    simulariumFileName={displayName}
+                    lastModified={lastModified}
+                />
                 <div className={styles.buttons}>
                     <LoadFileMenu
                         key="select"

--- a/src/containers/AppHeader/style.css
+++ b/src/containers/AppHeader/style.css
@@ -53,14 +53,6 @@
     font-weight: 100;
 }
 
-.viewer-title {
-    white-space: nowrap;
-    overflow: hidden;
-    max-width: calc(100vw - 562px);
-    /* text-overflow: ellipsis; */
-    /* display: inline-block; */
-}
-
 .buttons {
     display: flex;
     justify-content: flex-end;

--- a/src/containers/AppHeader/style.css
+++ b/src/containers/AppHeader/style.css
@@ -32,6 +32,11 @@
     margin-left: 12px;
 }
 
+.left-links {
+    white-space: nowrap;
+    margin-right: 2em;
+}
+
 .home {
     margin-left: 2px;
     margin-right: 20px;
@@ -48,6 +53,14 @@
     font-weight: 100;
 }
 
+.viewer-title {
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: calc(100vw - 562px);
+    /* text-overflow: ellipsis; */
+    /* display: inline-block; */
+}
+
 .buttons {
     display: flex;
     justify-content: flex-end;
@@ -61,7 +74,7 @@
     }
 
     .buttons {
-        min-width: 282px;
+        min-width: 305px;
     }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -113,7 +113,7 @@ use the :after pseduo selector to input the content.
     content: "\e907";
 }
 
-.ant-tooltip-inner {
+.ant-tooltip-inner, .ant-popover-inner {
     border-radius: 3px;
     font-weight: 300;
     box-shadow: 2px 2px 3px black;

--- a/src/styles/ant-vars.less
+++ b/src/styles/ant-vars.less
@@ -264,3 +264,23 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 // Tag
 @tag-default-bg: @allen-purple;
 @tag-default-color: @white-six;
+
+// Popover
+// ---
+// Popover body background color
+@popover-bg: @dark-purple;
+// Popover text color
+@popover-color: #fff;
+// Popover maximum width
+@popover-min-width: 177px;
+@popover-min-height: 32px;
+// Popover arrow width
+@popover-arrow-width: 6px;
+// Popover arrow color
+@popover-arrow-color: @popover-bg;
+// Popover outer arrow width
+// Popover outer arrow color
+@popover-arrow-outer-color: @popover-bg;
+// Popover distance with trigger
+@popover-distance: 0px;
+@popover-padding-horizontal: @padding-md;


### PR DESCRIPTION
Problem
=======
Closes #268 

Solution
========
* Prevent nav bar contents from spilling out of the nav bar, for any reason
* Truncate a long trajectory title with "..." 
* Upon hovering over the trajectory title, show the full trajectory title in a tooltip after 1 second. Tooltip disappears immediately upon leaving the trajectory title.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Clone this repo 
2. Pull this branch
3. `npm i` then `npm start`
4. Try to repro the bug as outlined in the issue, nothing should overflow from the nav bar anymore.

Screenshots (optional):
-----------------------
![image](https://user-images.githubusercontent.com/12690133/148137400-eba41b4b-47e5-4acf-8f35-becf48193e02.png)


Upon hover:
![image](https://user-images.githubusercontent.com/12690133/148137604-474736e6-2254-4088-ba15-96fca8ea1195.png)
