### PR TITLE
Fix/can't step back to first frame of some trajectories

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -1,6 +1,7 @@
 import React, { KeyboardEvent, useState } from "react";
 import { Button, Slider, Tooltip, InputNumber } from "antd";
 import classNames from "classnames";
+import { compareTimes } from "@aics/simularium-viewer";
 
 import { TOOLTIP_COLOR } from "../../constants/index";
 import Icons from "../Icons";
@@ -109,6 +110,13 @@ const PlayBackControls = ({
 
     const btnClassNames = classNames([styles.item, styles.btn]);
 
+    // Disable step back button if time - timeStep < firstFrameTime
+    const isStepBackDisabled =
+        compareTimes(time - timeStep, firstFrameTime, timeStep) === -1;
+    // Disable step forward button if time + timeStep > lastFrameTime
+    const isStepForwardDisabled =
+        compareTimes(time + timeStep, lastFrameTime, timeStep) === 1;
+
     return (
         <div className={styles.container}>
             <Tooltip
@@ -123,9 +131,7 @@ const PlayBackControls = ({
                     ])}
                     size="small"
                     onClick={prevHandler}
-                    disabled={
-                        time - timeStep < firstFrameTime || loading || isEmpty
-                    }
+                    disabled={isStepBackDisabled || loading || isEmpty}
                     loading={loading}
                 >
                     {/* if loading, antd will show loading icon, otherwise, show our custom svg */}
@@ -166,9 +172,7 @@ const PlayBackControls = ({
                     ])}
                     size="small"
                     onClick={nextHandler}
-                    disabled={
-                        time + timeStep > lastFrameTime || loading || isEmpty
-                    }
+                    disabled={isStepForwardDisabled || loading || isEmpty}
                     loading={loading}
                 >
                     {/* if loading, antd will show loading icon, otherwise, show our custom svg */}


### PR DESCRIPTION
Problem
=======
Closes #171 

Solution
========
Seems to have been a floating point math error. Instead of using simple comparisons of time values, I used the `compareTimes` function (from simularium-viewer) to more accurately compare time values when determining whether the step back and step forward buttons should be disabled or not. More about the `compareTimes` function [here](https://github.com/simularium/simularium-viewer/blob/7f3cac1adcff84b83b34413b77933f4e401bdb68/src/util.ts#L1).

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch, `npm start`
2. Go to http://localhost:9001/viewer?trajFileName=nanoparticle_wrapping.simularium
3. Step forward. Notice how the step back button is now enabled and you can step back.
4. Repeat steps 2-3 with http://localhost:9001/viewer?trajFileName=medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.675.simularium
