### PR TITLE
Update GitHub URLs to reflect new Simularium org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Automatically builds from `main`
 1. Make a new version: `npm version [patch/minor/major]`
 2. Push the new package.json version: `git push origin main`
 3. Push the new tag: `git push origin [NEW_TAG]`
-4. Go to the [releases page](https://github.com/allen-cell-animated/simularium-website/releases) and write the release notes for the new version. You can refer to the auto-generated [CHANGELOG.md][changelog] for a list of changes.
+4. Go to the [releases page](https://github.com/simularium/simularium-website/releases) and write the release notes for the new version. You can refer to the auto-generated [CHANGELOG.md][changelog] for a list of changes.
 
 [changelog]: CHANGELOG.md
 
@@ -79,7 +79,7 @@ Automatically builds from `main`
     * **Shiny new feature 2** - Description
 
     ### 🐛 Bug Fixes and Improvements
-    Updated [simularium-viewer](https://github.com/allen-cell-animated/simularium-viewer) to from vx.x.x to vx.x.x, which includes:
+    Updated [simularium-viewer](https://github.com/simularium/simularium-viewer) to from vx.x.x to vx.x.x, which includes:
     * Something nice
     * Something else nice
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ## Simularium repositories
 This repository is part of the Simularium project ([simularium.allencell.org](https://simularium.allencell.org)), which includes repositories:
-- [simulariumIO](https://github.com/allen-cell-animated/simulariumio) - Python package that converts simulation outputs to the format consumed by the Simularium viewer website
-- [simularium-engine](https://github.com/allen-cell-animated/simularium-engine) - C++ backend application that interfaces with biological simulation engines and serves simulation data to the front end website
-- [simularium-viewer](https://github.com/allen-cell-animated/simularium-viewer) - NPM package to view Simularium trajectories in 3D
-- [simularium-website](https://github.com/allen-cell-animated/simularium-website) - Front end website for the Simularium project, includes the Simularium viewer
+- [simulariumIO](https://github.com/simularium/simulariumio) - Python package that converts simulation outputs to the format consumed by the Simularium viewer website
+- [simularium-engine](https://github.com/simularium/simularium-engine) - C++ backend application that interfaces with biological simulation engines and serves simulation data to the front end website
+- [simularium-viewer](https://github.com/simularium/simularium-viewer) - NPM package to view Simularium trajectories in 3D
+- [simularium-website](https://github.com/simularium/simularium-website) - Front end website for the Simularium project, includes the Simularium viewer
 
 ---
 
-![Node.js CI](https://github.com/allen-cell-animated/simularium-website/workflows/Node.js%20CI/badge.svg)
+![Node.js CI](https://github.com/simularium/simularium-website/workflows/Node.js%20CI/badge.svg)
 
 # Simularium Website
 

--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -116,7 +116,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                 <li>
                                     These{" "}
                                     <a
-                                        href="https://github.com/allen-cell-animated/simulariumio/tree/main/examples"
+                                        href="https://github.com/simularium/simulariumio/tree/main/examples"
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >
@@ -157,7 +157,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                         {SUPPORTED_ENGINES.map(
                                             (engine: string[]) => {
                                                 const name = engine[0];
-                                                const url = `https://github.com/allen-cell-animated/simulariumio/blob/main/examples/Tutorial_${name.toLowerCase()}.ipynb`;
+                                                const url = `https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_${name.toLowerCase()}.ipynb`;
                                                 return (
                                                     <li key={name}>
                                                         <a
@@ -178,7 +178,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                     your data, choose the notebook for
                                     converting{" "}
                                     <a
-                                        href="https://github.com/allen-cell-animated/simulariumio/blob/main/examples/Tutorial_custom.ipynb"
+                                        href="https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_custom.ipynb"
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,9 +18,9 @@ export const FORUM_URL =
 // Note that below has "/tags/" unlike FORUM_URL
 export const FORUM_BUG_REPORT_URL =
     "https://forum.allencell.org/tags/c/software-code/simularium/15/bug-report";
-export const GITHUB_URL = "https://github.com/allen-cell-animated?q=simularium";
+export const GITHUB_URL = "https://github.com/simularium";
 export const ISSUE_URL =
-    "https://github.com/allen-cell-animated/simularium-website/issues";
+    "https://github.com/simularium/simularium-website/issues";
 export const CONTACT_FORM_URL = "https://forms.gle/mwoJjaj3PcbTVStU7";
 export const CYTOSIM_URL = "https://gitlab.com/f.nedelec/cytosim";
 export const PHYSICELL_URL = "http://physicell.org/";
@@ -41,7 +41,7 @@ export const SUPPORTED_ENGINES = [
 ];
 
 // If any these URLs are used as a trajUrl param, we want to redirect to a networked file
-// More info: https://github.com/allen-cell-animated/simularium-website/issues/213
+// More info: https://github.com/simularium/simularium-website/issues/213
 export const USER_TRAJ_REDIRECTS = [
     "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_Below_Ksp.simularium",
     "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_At_Ksp.simularium",


### PR DESCRIPTION
Problem 
=======
Closes #289 

Solution
=======
* Update URL specified in above issue
* Also update all the other URLs in this repo that refer to the allen-cell-animated org


