### PR TITLE
Fix/server error messages not displaying

### DIFF
--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from "axios";
-import { batch, useDispatch } from "react-redux";
+import { batch } from "react-redux";
 import { createLogic } from "redux-logic";
+import { ArgumentAction } from "redux-logic/definitions/action";
 import queryString from "query-string";
 import { ErrorLevel, FrontEndError } from "@aics/simularium-viewer";
 
@@ -106,9 +107,12 @@ const requestPlotDataLogic = createLogic({
     type: REQUEST_PLOT_DATA,
 });
 
-const handleFileLoadError = (error: FrontEndError) => {
-    const dispatch = useDispatch();
-
+const handleFileLoadError = (
+    error: FrontEndError,
+    dispatch: <T extends ArgumentAction<string, undefined, undefined>>(
+        action: T
+    ) => T
+) => {
     batch(() => {
         dispatch(
             setError({
@@ -178,7 +182,7 @@ const loadNetworkedFile = createLogic({
             })
             .then(done)
             .catch((error: FrontEndError) => {
-                handleFileLoadError(error);
+                handleFileLoadError(error, dispatch);
                 done();
             });
     },
@@ -238,7 +242,7 @@ const loadLocalFile = createLogic({
             })
             .then(done)
             .catch((error: FrontEndError) => {
-                handleFileLoadError(error);
+                handleFileLoadError(error, dispatch);
                 done();
             });
     },


### PR DESCRIPTION
Problem
=======
Server error messages aren't displaying to the user like they're supposed to. 

Closes #302 

Solution
========
This bug was happening because I was misusing a React hook (`useDispatch`) -- React hooks can only be used inside a function component. I was using it in a helper function for a redux logic function. 

I fixed the issue by passing in `dispatch` to the helper function from the invoking logic function instead. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Change the dev server URL in webpack/plugins.js to something invalid
2. `npm start`
3. Try to load a model
4. After a few seconds of attempting to load, the viewer should reset, and you should see an error message like this:

![image](https://user-images.githubusercontent.com/12690133/150453407-fa8ae45c-6ca5-4305-b38f-7377c8ef8ff7.png)
