### PR TITLE
Add return type to React components

### DIFF
--- a/src/components/BlankCard/index.tsx
+++ b/src/components/BlankCard/index.tsx
@@ -7,7 +7,7 @@ import ImportThumbnail from "../../assets/import-thumbnail.svg";
 
 const styles = require("../ModelCard/style.css");
 
-const BlankCard = () => {
+const BlankCard = (): JSX.Element => {
     return (
         <Card
             className={styles.card}

--- a/src/components/CameraControls/index.tsx
+++ b/src/components/CameraControls/index.tsx
@@ -31,7 +31,7 @@ const CameraControls = ({
     zoomOut,
     setPanningMode,
     setFocusMode,
-}: CameraControlsProps) => {
+}: CameraControlsProps): JSX.Element => {
     const [isFocused, saveFocusMode] = useState(true);
     const [mode, setMode] = useState(ROTATE);
     const [keyPressed, setKeyPressed] = useState("");

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -26,9 +26,7 @@ const tooltipOffsets: TooltipOffsets = {
     shared: [0, -3],
 };
 
-const Checkbox: React.FunctionComponent<CheckboxTypeProps> = (
-    props: CheckboxTypeProps
-) => {
+const Checkbox = (props: CheckboxTypeProps): JSX.Element => {
     // removing props that are only needed at this level
     const childProps = { ...props, checkboxType: null, checkboxLevel: null };
     const checkboxLevel = props.checkboxLevel ? props.checkboxLevel : "default";

--- a/src/components/CheckboxTreeSubmenu/index.tsx
+++ b/src/components/CheckboxTreeSubmenu/index.tsx
@@ -21,7 +21,7 @@ const CheckboxTreeSubmenu = ({
     options,
     onChange,
     checkboxType,
-}: CheckboxTreeSubmenuProps) => {
+}: CheckboxTreeSubmenuProps): JSX.Element => {
     const onCheckboxChange = ({ target }: CheckboxChangeEvent) => {
         const allowedValues = map(options, "value");
         const optionIndex = checkedAgents.indexOf(target.value);

--- a/src/components/ColorSwatch/index.tsx
+++ b/src/components/ColorSwatch/index.tsx
@@ -6,7 +6,7 @@ interface ColorSwatchProps {
     color: string;
 }
 
-const ColorSwatch = ({ color }: ColorSwatchProps) => {
+const ColorSwatch = ({ color }: ColorSwatchProps): JSX.Element => {
     return (
         <div className={styles.container} style={{ backgroundColor: color }} />
     );

--- a/src/components/ErrorNotification/index.tsx
+++ b/src/components/ErrorNotification/index.tsx
@@ -11,12 +11,14 @@ interface ErrorNotificationProps {
     onClose?: () => void;
 }
 
+// Technically this function does not return a JSX.Element, but it is
+// like a React component
 const ErrorNotification = ({
     level,
     message,
     htmlData,
     onClose,
-}: ErrorNotificationProps): JSX.Element => {
+}: ErrorNotificationProps) => {
     // Sometimes the message that comes in at runtime is an entire
     // Error object instead of a string
     if (typeof message !== "string") {

--- a/src/components/ErrorNotification/index.tsx
+++ b/src/components/ErrorNotification/index.tsx
@@ -16,7 +16,7 @@ const ErrorNotification = ({
     message,
     htmlData,
     onClose,
-}: ErrorNotificationProps) => {
+}: ErrorNotificationProps): JSX.Element => {
     // Sometimes the message that comes in at runtime is an entire
     // Error object instead of a string
     if (typeof message !== "string") {

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -6,7 +6,7 @@ const { Footer: AntdFooter } = Layout;
 
 const styles = require("./style.css");
 
-const Footer = () => {
+const Footer = (): JSX.Element => {
     return (
         <AntdFooter className={styles.container}>
             <Row justify="space-around">

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -13,7 +13,7 @@ import {
 
 const styles = require("./style.css");
 
-const HelpMenu = () => {
+const HelpMenu = (): JSX.Element => {
     const location = useLocation();
     const tutorialLink =
         location.pathname === "/viewer" ? (

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -18,7 +18,7 @@ const NUM_CARDS_PER_ROW = 3;
 // Add bullets to each heading
 const markdownProcessed = markdown.default.replaceAll("##", "## &bull;");
 
-const LandingPage = () => {
+const LandingPage = (): JSX.Element => {
     return (
         <React.Fragment>
             <Content className={styles.content}>

--- a/src/components/LoadFileMenu/index.tsx
+++ b/src/components/LoadFileMenu/index.tsx
@@ -38,7 +38,7 @@ const LoadFileMenu = ({
     selectFile,
     setViewerStatus,
     setError,
-}: LoadFileMenuProps) => {
+}: LoadFileMenuProps): JSX.Element => {
     const location = useLocation();
     const onClick = (trajectoryData: TrajectoryDisplayData) => {
         if (location.pathname === VIEWER_PATHNAME) {

--- a/src/components/LocalFileUpload/index.tsx
+++ b/src/components/LocalFileUpload/index.tsx
@@ -38,7 +38,7 @@ const LocalFileUpload = ({
     setViewerStatus,
     clearSimulariumFile,
     setError,
-}: FileUploadProps) => {
+}: FileUploadProps): JSX.Element => {
     const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
 
     const onChange = ({ file }: UploadChangeParam) => {

--- a/src/components/ModelCard/index.tsx
+++ b/src/components/ModelCard/index.tsx
@@ -14,7 +14,7 @@ interface ModelCardProps {
 
 const ModelCard: React.FunctionComponent<ModelCardProps> = (
     props: ModelCardProps
-) => {
+): JSX.Element => {
     const {
         id,
         title,

--- a/src/components/NestedMenus/index.tsx
+++ b/src/components/NestedMenus/index.tsx
@@ -14,10 +14,7 @@ interface NestedMenusProps {
     content: (JSX.Element | null)[];
 }
 
-export default class NestedMenus extends React.Component<
-    NestedMenusProps,
-    Record<string, never>
-> {
+export default class NestedMenus extends React.Component<NestedMenusProps> {
     public render(): JSX.Element {
         const { panelKeys, mainTitle, subTitles, content } = this.props;
         return (

--- a/src/components/NoTrajectoriesText/NetworkFileFailedText.tsx
+++ b/src/components/NoTrajectoriesText/NetworkFileFailedText.tsx
@@ -3,7 +3,7 @@ import { FORUM_BUG_REPORT_URL, ISSUE_URL } from "../../constants";
 
 const styles = require("./style.css");
 
-const NetworkFileFailedText = () => {
+const NetworkFileFailedText = (): JSX.Element => {
     return (
         <div className={styles.container}>
             <h3>Simulation failed to load</h3>

--- a/src/components/NoTrajectoriesText/NoTypeMappingText.tsx
+++ b/src/components/NoTrajectoriesText/NoTypeMappingText.tsx
@@ -5,7 +5,7 @@ import { DATA_BUCKET_URL } from "../../constants";
 
 const styles = require("../NoTrajectoriesText/style.css");
 
-const NoTypeMappingText = () => {
+const NoTypeMappingText = (): JSX.Element => {
     return (
         <div className={styles.container}>
             <h3>Unable to load UI controls</h3>

--- a/src/components/NoTrajectoriesText/index.tsx
+++ b/src/components/NoTrajectoriesText/index.tsx
@@ -14,7 +14,9 @@ interface NoTrajectoriesTextProps {
     selectFile: ActionCreator<RequestNetworkFileAction>;
 }
 
-const NoTrajectoriesText = ({ selectFile }: NoTrajectoriesTextProps) => {
+const NoTrajectoriesText = ({
+    selectFile,
+}: NoTrajectoriesTextProps): JSX.Element => {
     const handleClick = (trajectoryData: TrajectoryDisplayData) => {
         selectFile({
             name: trajectoryData.id,

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -41,7 +41,7 @@ const PlayBackControls = ({
     displayTimes,
     timeUnits,
     isEmpty,
-}: PlayBackProps) => {
+}: PlayBackProps): JSX.Element => {
     // Where to resume playing if simulation was playing before scrubbing
     const [
         timeToResumeAfterScrubbing,

--- a/src/components/ScaleBar/index.tsx
+++ b/src/components/ScaleBar/index.tsx
@@ -7,7 +7,7 @@ interface ScaleBarProps {
     label: string;
 }
 
-const ScaleBar = (scaleBarProps: ScaleBarProps) => {
+const ScaleBar = (scaleBarProps: ScaleBarProps): JSX.Element => {
     const { label } = scaleBarProps;
     const scaleBarNode = label ? (
         <div className={styles.container}>

--- a/src/components/ScrollToTop/index.tsx
+++ b/src/components/ScrollToTop/index.tsx
@@ -9,7 +9,7 @@ Source: https://reactrouter.com/web/guides/scroll-restoration
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
-const ScrollToTop = () => {
+const ScrollToTop = (): null => {
     const { pathname } = useLocation();
 
     useEffect(() => {

--- a/src/components/SharedCheckbox/index.tsx
+++ b/src/components/SharedCheckbox/index.tsx
@@ -20,8 +20,7 @@ interface SharedCheckboxProps {
 }
 
 export default class SharedCheckbox extends React.Component<
-    SharedCheckboxProps,
-    Record<string, never>
+    SharedCheckboxProps
 > {
     constructor(props: SharedCheckboxProps) {
         super(props);

--- a/src/components/SideBarContents/index.tsx
+++ b/src/components/SideBarContents/index.tsx
@@ -9,8 +9,7 @@ interface SideBarContentsProps {
 }
 
 export default class SideBarContents extends React.Component<
-    SideBarContentsProps,
-    Record<string, never>
+    SideBarContentsProps
 > {
     public render(): JSX.Element {
         const { mainTitle, content } = this.props;

--- a/src/components/StarCheckbox/index.tsx
+++ b/src/components/StarCheckbox/index.tsx
@@ -10,13 +10,13 @@ import {
 
 const styles = require("./style.css");
 
-const StarCheckbox: React.FunctionComponent<CheckboxProps> = ({
+const StarCheckbox = ({
     checked,
     indeterminate,
     onChange,
     value,
     className,
-}: CheckboxProps) => {
+}: CheckboxProps): JSX.Element => {
     const parentClassnames = className ? className.split(" ") : [];
     const wrapperClassnames = classNames([...parentClassnames, styles.wrapper]);
     const checkboxClassNames = classNames(["icon-moon", styles.checkbox], {

--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -13,7 +13,7 @@ const { Text } = Typography;
 
 const styles = require("./style.css");
 
-const TutorialPage = () => {
+const TutorialPage = (): JSX.Element => {
     return (
         <>
             <Content className={styles.content}>

--- a/src/components/UrlUpload/index.tsx
+++ b/src/components/UrlUpload/index.tsx
@@ -6,7 +6,7 @@ import { TUTORIAL_PATHNAME, VIEWER_PATHNAME } from "../../routes";
 
 const styles = require("./style.css");
 
-const UrlUpload = () => {
+const UrlUpload = (): JSX.Element => {
     const [isModalVisible, setIsModalVisible] = useState(false);
     const [userInput, setUserInput] = useState("");
     const history = useHistory();

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -15,7 +15,7 @@ interface ViewerTitleProps {
 
 const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
     props: ViewerTitleProps
-) => {
+): JSX.Element => {
     const { simulariumFileName, lastModified } = props;
     const location = useLocation();
     const title =

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -25,7 +25,7 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
     );
 });
 
-const VisualGlossary = () => {
+const VisualGlossary = (): JSX.Element => {
     return (
         <div className={styles.container}>
             <img src={visualGlossaryImage} />

--- a/src/containers/AppHeader/index.tsx
+++ b/src/containers/AppHeader/index.tsx
@@ -36,7 +36,7 @@ interface AppHeaderProps {
     setError: ActionCreator<SetErrorAction>;
 }
 
-class AppHeader extends React.Component<AppHeaderProps, Record<string, never>> {
+class AppHeader extends React.Component<AppHeaderProps> {
     public render(): JSX.Element {
         const {
             simulariumFile,

--- a/src/containers/ModelPanel/index.tsx
+++ b/src/containers/ModelPanel/index.tsx
@@ -64,10 +64,7 @@ interface ModelPanelProps {
     changeToNetworkedFile: ActionCreator<RequestNetworkFileAction>;
 }
 
-class ModelPanel extends React.Component<
-    ModelPanelProps,
-    Record<string, never>
-> {
+class ModelPanel extends React.Component<ModelPanelProps> {
     public render(): JSX.Element {
         const {
             agentVisibilityMap,

--- a/src/containers/ResultsPanel/index.tsx
+++ b/src/containers/ResultsPanel/index.tsx
@@ -14,10 +14,7 @@ interface ResultsPanelProps {
     plotConfigs: PlotConfig[];
 }
 
-class ResultsPanel extends React.Component<
-    ResultsPanelProps,
-    Record<string, never>
-> {
+class ResultsPanel extends React.Component<ResultsPanelProps> {
     public render(): JSX.Element {
         const { plotConfigs } = this.props;
         const content =


### PR DESCRIPTION
Problem
=======
Since #306 was merged, some React components are missing return types. 

Solution
========
* ~90% of the changes in this PR are just adding the return type `JSX.Element` to function components.
* ~9% of the changes are just removing `Record<string, never>` (implying no component state) from some of the class components because they're unnecessary.
* The other few changes are pointed out in the diff

## Type of change
Please delete options that are not relevant.

* Maintenance (non-breaking change which should have no effect on functionality)

Steps to Verify:
----------------
1. `npm run typeCheck` still passes
2. App still runs like before
