### PR TITLE
Feature/place visual glossary key next to image on wider screens

### DIFF
--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -19,284 +19,269 @@ const TutorialPage = (): JSX.Element => {
             <Content className={styles.content}>
                 <h1>Getting Started with Simularium</h1>
                 <VisualGlossary />
-                <div className={styles.text}>
-                    <p className={styles.intro}>
-                        To try out the Simularium Viewer, either{" "}
-                        <a
-                            href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                <p className={styles.intro}>
+                    To try out the Simularium Viewer, either{" "}
+                    <a
+                        href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                    >
+                        download
+                    </a>{" "}
+                    our example data or <a href="#convert-your-data">convert</a>{" "}
+                    your own data, and drag and drop it onto the{" "}
+                    <Link to={VIEWER_PATHNAME}>viewer</Link>. More details
+                    below:
+                </p>
+                <ul className={styles.approachBlock}>
+                    <li>
+                        <span className={styles.listHeader}>
+                            Drag and drop example data
+                        </span>
+                        <br />
+                        <img
+                            className={styles.dragDropImage}
+                            src={dragDropImage}
+                        />
+                    </li>
+                    <ol>
+                        <li>
+                            Download the example data{" "}
+                            <a
+                                href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                            >
+                                here
+                            </a>
+                            .
+                        </li>
+                        <li>
+                            In a web browser (Firefox, Chrome, or Edge),
+                            navigate to the{" "}
+                            <Link to={VIEWER_PATHNAME}>Simularium viewer</Link>.
+                        </li>
+                        <li>
+                            Drag one of the downloaded files from your file
+                            browser onto the the window.
+                        </li>
+                    </ol>
+                </ul>
+                <ul className={styles.approachBlock}>
+                    <li>
+                        <span
+                            id="convert-your-data"
+                            className={styles.listHeader}
                         >
-                            download
-                        </a>{" "}
-                        our example data or{" "}
-                        <a href="#convert-your-data">convert</a> your own data,
-                        and drag and drop it onto the{" "}
-                        <Link to={VIEWER_PATHNAME}>viewer</Link>. More details
-                        below:
-                    </p>
-                    <ul className={styles.approachBlock}>
+                            Convert your data into Simularium format
+                        </span>
+                    </li>
+                    <ol>
                         <li>
-                            <span className={styles.listHeader}>
-                                Drag and drop example data
-                            </span>
-                            <br />
-                            <img
-                                className={styles.dragDropImage}
-                                src={dragDropImage}
-                            />
-                        </li>
-                        <ol>
-                            <li>
-                                Download the example data{" "}
-                                <a
-                                    href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
-                                >
-                                    here
-                                </a>
-                                .
-                            </li>
-                            <li>
-                                In a web browser (Firefox, Chrome, or Edge),
-                                navigate to the{" "}
-                                <Link to={VIEWER_PATHNAME}>
-                                    Simularium viewer
-                                </Link>
-                                .
-                            </li>
-                            <li>
-                                Drag one of the downloaded files from your file
-                                browser onto the the window.
-                            </li>
-                        </ol>
-                    </ul>
-                    <ul className={styles.approachBlock}>
-                        <li>
-                            <span
-                                id="convert-your-data"
-                                className={styles.listHeader}
+                            Install{" "}
+                            <a
+                                href="https://docs.conda.io/en/latest/miniconda.html"
+                                target="_blank"
+                                rel="noopener noreferrer"
                             >
-                                Convert your data into Simularium format
-                            </span>
+                                Anaconda
+                            </a>{" "}
+                            if you have not already.
                         </li>
-                        <ol>
-                            <li>
-                                Install{" "}
-                                <a
-                                    href="https://docs.conda.io/en/latest/miniconda.html"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    Anaconda
-                                </a>{" "}
-                                if you have not already.
-                            </li>
-                            <li>
-                                In a terminal window, create and activate a new
-                                conda environment using either Python 3.7 or
-                                3.8:
-                                <p>
-                                    <Text code>
-                                        conda create -n simularium python=3.8
-                                    </Text>
-                                    <br />
-                                    <Text code>conda activate simularium</Text>
-                                </p>
-                            </li>
-                            <li>
-                                Install the simulariumio Python package:
-                                <p>
-                                    <Text code>pip install simulariumio</Text>
-                                </p>
-                            </li>
-                            <li>
-                                In your Python script, import the converter and
-                                data you need from simulariumio, e.g. for data
-                                generated by an engine not specifically
-                                supported by simulariumio:
-                                <p>
-                                    <Text code>
-                                        from simulariumio import
-                                        CustomConverter, CustomData, AgentData
-                                    </Text>
-                                </p>
-                                <ul>
-                                    <li>
-                                        These{" "}
-                                        <a
-                                            href="https://github.com/simularium/simulariumio/tree/main/examples"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            Jupyter notebooks
-                                        </a>{" "}
-                                        provide examples of saving data from
-                                        different sources in Simularium’s input
-                                        format.
-                                    </li>
-                                    <li>
-                                        We support the following simulators:
-                                        <ul>
-                                            {SUPPORTED_ENGINES.map(
-                                                (engine: string[]) => {
-                                                    const [name, url] = engine;
-                                                    return (
-                                                        <li key={name}>
-                                                            {name} (
-                                                            <a
-                                                                href={url}
-                                                                target="_blank"
-                                                                rel="noopener noreferrer"
-                                                            >
-                                                                {url}
-                                                            </a>
-                                                            )
-                                                        </li>
-                                                    );
-                                                }
-                                            )}
-                                        </ul>
-                                    </li>
-                                    <li>
-                                        If you used one of our supported
-                                        simulators to generate your data, choose
-                                        the notebook for that simulator:
-                                        <ul>
-                                            {SUPPORTED_ENGINES.map(
-                                                (engine: string[]) => {
-                                                    const name = engine[0];
-                                                    const url = `https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_${name.toLowerCase()}.ipynb`;
-                                                    return (
-                                                        <li key={name}>
-                                                            <a
-                                                                href={url}
-                                                                target="_blank"
-                                                                rel="noopener noreferrer"
-                                                            >
-                                                                {name}
-                                                            </a>
-                                                        </li>
-                                                    );
-                                                }
-                                            )}
-                                        </ul>
-                                    </li>
-                                    <li>
-                                        If you used another simulator to
-                                        generate your data, choose the notebook
-                                        for converting{" "}
-                                        <a
-                                            href="https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_custom.ipynb"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            custom data
-                                        </a>
-                                        .
-                                    </li>
-                                </ul>
-                            </li>
-                            <li>
-                                Run your Python script and notice a file
-                                generated at the output path you provided.
-                            </li>
-                            <li>
-                                In a web browser (Firefox, Chrome, or Edge),
-                                navigate to the{" "}
-                                <Link to={VIEWER_PATHNAME}>
-                                    Simularium viewer
-                                </Link>
-                                .
-                            </li>
-                            <li>
-                                Drag the resulting file from your file browser
-                                onto the window or choose Load model &gt; From
-                                your device, and select your file from the file
-                                upload dialogue.
-                                <ul>
-                                    <li>
-                                        If you&apos;re using local geometry
-                                        files, like .obj or .pdb files, load
-                                        them at the same time as you load your
-                                        .simularium file, either by dragging and
-                                        dropping a collection of files, or by
-                                        choosing multiple files in the upload
-                                        dialogue.
-                                    </li>
-                                    <li>
-                                        Currently the Viewer does not support
-                                        loading folders of files, so make sure
-                                        you are loading a collection of single
-                                        files that does not include a folder.
-                                        We&apos;re working to improve this.
-                                    </li>
-                                </ul>
-                            </li>
-                        </ol>
-                    </ul>
-                    <ul className={styles.approachBlock}>
                         <li>
-                            <span
-                                id="share-a-link"
-                                className={styles.listHeader}
-                            >
-                                Share a link to your data
-                            </span>
+                            In a terminal window, create and activate a new
+                            conda environment using either Python 3.7 or 3.8:
+                            <p>
+                                <Text code>
+                                    conda create -n simularium python=3.8
+                                </Text>
+                                <br />
+                                <Text code>conda activate simularium</Text>
+                            </p>
                         </li>
-                        <ol>
-                            <li>
-                                Upload your Simularium file to one of the
-                                supported public cloud providers, including
-                                Dropbox, Google Drive, or Amazon S3, and get a
-                                publicly accessible link to the file.
-                            </li>
-                            <li>
-                                In a supported browser, navigate to{" "}
-                                <Link
-                                    to="/"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    https://simularium.allencell.org/
-                                </Link>
-                                .
-                            </li>
-                            <li>
-                                Choose Load model &gt; From a URL. In the
-                                dialog, provide the URL to your Simularium file
-                                and choose Load.
-                            </li>
+                        <li>
+                            Install the simulariumio Python package:
+                            <p>
+                                <Text code>pip install simulariumio</Text>
+                            </p>
+                        </li>
+                        <li>
+                            In your Python script, import the converter and data
+                            you need from simulariumio, e.g. for data generated
+                            by an engine not specifically supported by
+                            simulariumio:
+                            <p>
+                                <Text code>
+                                    from simulariumio import CustomConverter,
+                                    CustomData, AgentData
+                                </Text>
+                            </p>
                             <ul>
                                 <li>
-                                    If your file uses geometry files, like .obj
-                                    or .pdb files, make sure you&apos;ve
-                                    provided the full public URL to the geometry
-                                    files in your .simularium file.
+                                    These{" "}
+                                    <a
+                                        href="https://github.com/simularium/simulariumio/tree/main/examples"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        Jupyter notebooks
+                                    </a>{" "}
+                                    provide examples of saving data from
+                                    different sources in Simularium’s input
+                                    format.
+                                </li>
+                                <li>
+                                    We support the following simulators:
+                                    <ul>
+                                        {SUPPORTED_ENGINES.map(
+                                            (engine: string[]) => {
+                                                const [name, url] = engine;
+                                                return (
+                                                    <li key={name}>
+                                                        {name} (
+                                                        <a
+                                                            href={url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                        >
+                                                            {url}
+                                                        </a>
+                                                        )
+                                                    </li>
+                                                );
+                                            }
+                                        )}
+                                    </ul>
+                                </li>
+                                <li>
+                                    If you used one of our supported simulators
+                                    to generate your data, choose the notebook
+                                    for that simulator:
+                                    <ul>
+                                        {SUPPORTED_ENGINES.map(
+                                            (engine: string[]) => {
+                                                const name = engine[0];
+                                                const url = `https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_${name.toLowerCase()}.ipynb`;
+                                                return (
+                                                    <li key={name}>
+                                                        <a
+                                                            href={url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                        >
+                                                            {name}
+                                                        </a>
+                                                    </li>
+                                                );
+                                            }
+                                        )}
+                                    </ul>
+                                </li>
+                                <li>
+                                    If you used another simulator to generate
+                                    your data, choose the notebook for
+                                    converting{" "}
+                                    <a
+                                        href="https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_custom.ipynb"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        custom data
+                                    </a>
+                                    .
                                 </li>
                             </ul>
+                        </li>
+                        <li>
+                            Run your Python script and notice a file generated
+                            at the output path you provided.
+                        </li>
+                        <li>
+                            In a web browser (Firefox, Chrome, or Edge),
+                            navigate to the{" "}
+                            <Link to={VIEWER_PATHNAME}>Simularium viewer</Link>.
+                        </li>
+                        <li>
+                            Drag the resulting file from your file browser onto
+                            the window or choose Load model &gt; From your
+                            device, and select your file from the file upload
+                            dialogue.
+                            <ul>
+                                <li>
+                                    If you&apos;re using local geometry files,
+                                    like .obj or .pdb files, load them at the
+                                    same time as you load your .simularium file,
+                                    either by dragging and dropping a collection
+                                    of files, or by choosing multiple files in
+                                    the upload dialogue.
+                                </li>
+                                <li>
+                                    Currently the Viewer does not support
+                                    loading folders of files, so make sure you
+                                    are loading a collection of single files
+                                    that does not include a folder. We&apos;re
+                                    working to improve this.
+                                </li>
+                            </ul>
+                        </li>
+                    </ol>
+                </ul>
+                <ul className={styles.approachBlock}>
+                    <li>
+                        <span id="share-a-link" className={styles.listHeader}>
+                            Share a link to your data
+                        </span>
+                    </li>
+                    <ol>
+                        <li>
+                            Upload your Simularium file to one of the supported
+                            public cloud providers, including Dropbox, Google
+                            Drive, or Amazon S3, and get a publicly accessible
+                            link to the file.
+                        </li>
+                        <li>
+                            In a supported browser, navigate to{" "}
+                            <Link
+                                to="/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                https://simularium.allencell.org/
+                            </Link>
+                            .
+                        </li>
+                        <li>
+                            Choose Load model &gt; From a URL. In the dialog,
+                            provide the URL to your Simularium file and choose
+                            Load.
+                        </li>
+                        <ul>
                             <li>
-                                Once the file is loaded, you can copy the page
-                                URL and share this link with collaborators or
-                                post it on your website so that others can
-                                interactively view your results.
+                                If your file uses geometry files, like .obj or
+                                .pdb files, make sure you&apos;ve provided the
+                                full public URL to the geometry files in your
+                                .simularium file.
                             </li>
-                        </ol>
-                    </ul>
-                    <h1 id="browser-support">Browser support</h1>
-                    <ul>
+                        </ul>
                         <li>
-                            Currently, Simularium supports Firefox, Chrome, and
-                            Edge. Some features may not work on other browsers.
+                            Once the file is loaded, you can copy the page URL
+                            and share this link with collaborators or post it on
+                            your website so that others can interactively view
+                            your results.
                         </li>
-                        <li>
-                            If using Safari on a Mac, please enable WebGL 2.0 by
-                            choosing Develop &gt; Experimental Features and
-                            enabling &quot;WebGL 2.0&quot; (If you do not have a
-                            Develop menu in your menu bar, please first choose
-                            Safari &gt; Preferences &gt; Advanced and enable
-                            &quot;Show Develop menu in menu bar&quot;.) Then
-                            please reload the viewer.
-                        </li>
-                    </ul>
-                </div>
+                    </ol>
+                </ul>
+                <h1 id="browser-support">Browser support</h1>
+                <ul>
+                    <li>
+                        Currently, Simularium supports Firefox, Chrome, and
+                        Edge. Some features may not work on other browsers.
+                    </li>
+                    <li>
+                        If using Safari on a Mac, please enable WebGL 2.0 by
+                        choosing Develop &gt; Experimental Features and enabling
+                        &quot;WebGL 2.0&quot; (If you do not have a Develop menu
+                        in your menu bar, please first choose Safari &gt;
+                        Preferences &gt; Advanced and enable &quot;Show Develop
+                        menu in menu bar&quot;.) Then please reload the viewer.
+                    </li>
+                </ul>
             </Content>
             <Footer />
         </>

--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -19,269 +19,284 @@ const TutorialPage = (): JSX.Element => {
             <Content className={styles.content}>
                 <h1>Getting Started with Simularium</h1>
                 <VisualGlossary />
-                <p className={styles.intro}>
-                    To try out the Simularium Viewer, either{" "}
-                    <a
-                        href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
-                    >
-                        download
-                    </a>{" "}
-                    our example data or <a href="#convert-your-data">convert</a>{" "}
-                    your own data, and drag and drop it onto the{" "}
-                    <Link to={VIEWER_PATHNAME}>viewer</Link>. More details
-                    below:
-                </p>
-                <ul className={styles.approachBlock}>
-                    <li>
-                        <span className={styles.listHeader}>
-                            Drag and drop example data
-                        </span>
-                        <br />
-                        <img
-                            className={styles.dragDropImage}
-                            src={dragDropImage}
-                        />
-                    </li>
-                    <ol>
-                        <li>
-                            Download the example data{" "}
-                            <a
-                                href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
-                            >
-                                here
-                            </a>
-                            .
-                        </li>
-                        <li>
-                            In a web browser (Firefox, Chrome, or Edge),
-                            navigate to the{" "}
-                            <Link to={VIEWER_PATHNAME}>Simularium viewer</Link>.
-                        </li>
-                        <li>
-                            Drag one of the downloaded files from your file
-                            browser onto the the window.
-                        </li>
-                    </ol>
-                </ul>
-                <ul className={styles.approachBlock}>
-                    <li>
-                        <span
-                            id="convert-your-data"
-                            className={styles.listHeader}
+                <div className={styles.text}>
+                    <p className={styles.intro}>
+                        To try out the Simularium Viewer, either{" "}
+                        <a
+                            href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
                         >
-                            Convert your data into Simularium format
-                        </span>
-                    </li>
-                    <ol>
+                            download
+                        </a>{" "}
+                        our example data or{" "}
+                        <a href="#convert-your-data">convert</a> your own data,
+                        and drag and drop it onto the{" "}
+                        <Link to={VIEWER_PATHNAME}>viewer</Link>. More details
+                        below:
+                    </p>
+                    <ul className={styles.approachBlock}>
                         <li>
-                            Install{" "}
-                            <a
-                                href="https://docs.conda.io/en/latest/miniconda.html"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                Anaconda
-                            </a>{" "}
-                            if you have not already.
+                            <span className={styles.listHeader}>
+                                Drag and drop example data
+                            </span>
+                            <br />
+                            <img
+                                className={styles.dragDropImage}
+                                src={dragDropImage}
+                            />
                         </li>
-                        <li>
-                            In a terminal window, create and activate a new
-                            conda environment using either Python 3.7 or 3.8:
-                            <p>
-                                <Text code>
-                                    conda create -n simularium python=3.8
-                                </Text>
-                                <br />
-                                <Text code>conda activate simularium</Text>
-                            </p>
-                        </li>
-                        <li>
-                            Install the simulariumio Python package:
-                            <p>
-                                <Text code>pip install simulariumio</Text>
-                            </p>
-                        </li>
-                        <li>
-                            In your Python script, import the converter and data
-                            you need from simulariumio, e.g. for data generated
-                            by an engine not specifically supported by
-                            simulariumio:
-                            <p>
-                                <Text code>
-                                    from simulariumio import CustomConverter,
-                                    CustomData, AgentData
-                                </Text>
-                            </p>
-                            <ul>
-                                <li>
-                                    These{" "}
-                                    <a
-                                        href="https://github.com/simularium/simulariumio/tree/main/examples"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        Jupyter notebooks
-                                    </a>{" "}
-                                    provide examples of saving data from
-                                    different sources in Simularium’s input
-                                    format.
-                                </li>
-                                <li>
-                                    We support the following simulators:
-                                    <ul>
-                                        {SUPPORTED_ENGINES.map(
-                                            (engine: string[]) => {
-                                                const [name, url] = engine;
-                                                return (
-                                                    <li key={name}>
-                                                        {name} (
-                                                        <a
-                                                            href={url}
-                                                            target="_blank"
-                                                            rel="noopener noreferrer"
-                                                        >
-                                                            {url}
-                                                        </a>
-                                                        )
-                                                    </li>
-                                                );
-                                            }
-                                        )}
-                                    </ul>
-                                </li>
-                                <li>
-                                    If you used one of our supported simulators
-                                    to generate your data, choose the notebook
-                                    for that simulator:
-                                    <ul>
-                                        {SUPPORTED_ENGINES.map(
-                                            (engine: string[]) => {
-                                                const name = engine[0];
-                                                const url = `https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_${name.toLowerCase()}.ipynb`;
-                                                return (
-                                                    <li key={name}>
-                                                        <a
-                                                            href={url}
-                                                            target="_blank"
-                                                            rel="noopener noreferrer"
-                                                        >
-                                                            {name}
-                                                        </a>
-                                                    </li>
-                                                );
-                                            }
-                                        )}
-                                    </ul>
-                                </li>
-                                <li>
-                                    If you used another simulator to generate
-                                    your data, choose the notebook for
-                                    converting{" "}
-                                    <a
-                                        href="https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_custom.ipynb"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        custom data
-                                    </a>
-                                    .
-                                </li>
-                            </ul>
-                        </li>
-                        <li>
-                            Run your Python script and notice a file generated
-                            at the output path you provided.
-                        </li>
-                        <li>
-                            In a web browser (Firefox, Chrome, or Edge),
-                            navigate to the{" "}
-                            <Link to={VIEWER_PATHNAME}>Simularium viewer</Link>.
-                        </li>
-                        <li>
-                            Drag the resulting file from your file browser onto
-                            the window or choose Load model &gt; From your
-                            device, and select your file from the file upload
-                            dialogue.
-                            <ul>
-                                <li>
-                                    If you&apos;re using local geometry files,
-                                    like .obj or .pdb files, load them at the
-                                    same time as you load your .simularium file,
-                                    either by dragging and dropping a collection
-                                    of files, or by choosing multiple files in
-                                    the upload dialogue.
-                                </li>
-                                <li>
-                                    Currently the Viewer does not support
-                                    loading folders of files, so make sure you
-                                    are loading a collection of single files
-                                    that does not include a folder. We&apos;re
-                                    working to improve this.
-                                </li>
-                            </ul>
-                        </li>
-                    </ol>
-                </ul>
-                <ul className={styles.approachBlock}>
-                    <li>
-                        <span id="share-a-link" className={styles.listHeader}>
-                            Share a link to your data
-                        </span>
-                    </li>
-                    <ol>
-                        <li>
-                            Upload your Simularium file to one of the supported
-                            public cloud providers, including Dropbox, Google
-                            Drive, or Amazon S3, and get a publicly accessible
-                            link to the file.
-                        </li>
-                        <li>
-                            In a supported browser, navigate to{" "}
-                            <Link
-                                to="/"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                https://simularium.allencell.org/
-                            </Link>
-                            .
-                        </li>
-                        <li>
-                            Choose Load model &gt; From a URL. In the dialog,
-                            provide the URL to your Simularium file and choose
-                            Load.
-                        </li>
-                        <ul>
+                        <ol>
                             <li>
-                                If your file uses geometry files, like .obj or
-                                .pdb files, make sure you&apos;ve provided the
-                                full public URL to the geometry files in your
-                                .simularium file.
+                                Download the example data{" "}
+                                <a
+                                    href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                                >
+                                    here
+                                </a>
+                                .
                             </li>
-                        </ul>
+                            <li>
+                                In a web browser (Firefox, Chrome, or Edge),
+                                navigate to the{" "}
+                                <Link to={VIEWER_PATHNAME}>
+                                    Simularium viewer
+                                </Link>
+                                .
+                            </li>
+                            <li>
+                                Drag one of the downloaded files from your file
+                                browser onto the the window.
+                            </li>
+                        </ol>
+                    </ul>
+                    <ul className={styles.approachBlock}>
                         <li>
-                            Once the file is loaded, you can copy the page URL
-                            and share this link with collaborators or post it on
-                            your website so that others can interactively view
-                            your results.
+                            <span
+                                id="convert-your-data"
+                                className={styles.listHeader}
+                            >
+                                Convert your data into Simularium format
+                            </span>
                         </li>
-                    </ol>
-                </ul>
-                <h1 id="browser-support">Browser support</h1>
-                <ul>
-                    <li>
-                        Currently, Simularium supports Firefox, Chrome, and
-                        Edge. Some features may not work on other browsers.
-                    </li>
-                    <li>
-                        If using Safari on a Mac, please enable WebGL 2.0 by
-                        choosing Develop &gt; Experimental Features and enabling
-                        &quot;WebGL 2.0&quot; (If you do not have a Develop menu
-                        in your menu bar, please first choose Safari &gt;
-                        Preferences &gt; Advanced and enable &quot;Show Develop
-                        menu in menu bar&quot;.) Then please reload the viewer.
-                    </li>
-                </ul>
+                        <ol>
+                            <li>
+                                Install{" "}
+                                <a
+                                    href="https://docs.conda.io/en/latest/miniconda.html"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Anaconda
+                                </a>{" "}
+                                if you have not already.
+                            </li>
+                            <li>
+                                In a terminal window, create and activate a new
+                                conda environment using either Python 3.7 or
+                                3.8:
+                                <p>
+                                    <Text code>
+                                        conda create -n simularium python=3.8
+                                    </Text>
+                                    <br />
+                                    <Text code>conda activate simularium</Text>
+                                </p>
+                            </li>
+                            <li>
+                                Install the simulariumio Python package:
+                                <p>
+                                    <Text code>pip install simulariumio</Text>
+                                </p>
+                            </li>
+                            <li>
+                                In your Python script, import the converter and
+                                data you need from simulariumio, e.g. for data
+                                generated by an engine not specifically
+                                supported by simulariumio:
+                                <p>
+                                    <Text code>
+                                        from simulariumio import
+                                        CustomConverter, CustomData, AgentData
+                                    </Text>
+                                </p>
+                                <ul>
+                                    <li>
+                                        These{" "}
+                                        <a
+                                            href="https://github.com/simularium/simulariumio/tree/main/examples"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            Jupyter notebooks
+                                        </a>{" "}
+                                        provide examples of saving data from
+                                        different sources in Simularium’s input
+                                        format.
+                                    </li>
+                                    <li>
+                                        We support the following simulators:
+                                        <ul>
+                                            {SUPPORTED_ENGINES.map(
+                                                (engine: string[]) => {
+                                                    const [name, url] = engine;
+                                                    return (
+                                                        <li key={name}>
+                                                            {name} (
+                                                            <a
+                                                                href={url}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                            >
+                                                                {url}
+                                                            </a>
+                                                            )
+                                                        </li>
+                                                    );
+                                                }
+                                            )}
+                                        </ul>
+                                    </li>
+                                    <li>
+                                        If you used one of our supported
+                                        simulators to generate your data, choose
+                                        the notebook for that simulator:
+                                        <ul>
+                                            {SUPPORTED_ENGINES.map(
+                                                (engine: string[]) => {
+                                                    const name = engine[0];
+                                                    const url = `https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_${name.toLowerCase()}.ipynb`;
+                                                    return (
+                                                        <li key={name}>
+                                                            <a
+                                                                href={url}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                            >
+                                                                {name}
+                                                            </a>
+                                                        </li>
+                                                    );
+                                                }
+                                            )}
+                                        </ul>
+                                    </li>
+                                    <li>
+                                        If you used another simulator to
+                                        generate your data, choose the notebook
+                                        for converting{" "}
+                                        <a
+                                            href="https://github.com/simularium/simulariumio/blob/main/examples/Tutorial_custom.ipynb"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            custom data
+                                        </a>
+                                        .
+                                    </li>
+                                </ul>
+                            </li>
+                            <li>
+                                Run your Python script and notice a file
+                                generated at the output path you provided.
+                            </li>
+                            <li>
+                                In a web browser (Firefox, Chrome, or Edge),
+                                navigate to the{" "}
+                                <Link to={VIEWER_PATHNAME}>
+                                    Simularium viewer
+                                </Link>
+                                .
+                            </li>
+                            <li>
+                                Drag the resulting file from your file browser
+                                onto the window or choose Load model &gt; From
+                                your device, and select your file from the file
+                                upload dialogue.
+                                <ul>
+                                    <li>
+                                        If you&apos;re using local geometry
+                                        files, like .obj or .pdb files, load
+                                        them at the same time as you load your
+                                        .simularium file, either by dragging and
+                                        dropping a collection of files, or by
+                                        choosing multiple files in the upload
+                                        dialogue.
+                                    </li>
+                                    <li>
+                                        Currently the Viewer does not support
+                                        loading folders of files, so make sure
+                                        you are loading a collection of single
+                                        files that does not include a folder.
+                                        We&apos;re working to improve this.
+                                    </li>
+                                </ul>
+                            </li>
+                        </ol>
+                    </ul>
+                    <ul className={styles.approachBlock}>
+                        <li>
+                            <span
+                                id="share-a-link"
+                                className={styles.listHeader}
+                            >
+                                Share a link to your data
+                            </span>
+                        </li>
+                        <ol>
+                            <li>
+                                Upload your Simularium file to one of the
+                                supported public cloud providers, including
+                                Dropbox, Google Drive, or Amazon S3, and get a
+                                publicly accessible link to the file.
+                            </li>
+                            <li>
+                                In a supported browser, navigate to{" "}
+                                <Link
+                                    to="/"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    https://simularium.allencell.org/
+                                </Link>
+                                .
+                            </li>
+                            <li>
+                                Choose Load model &gt; From a URL. In the
+                                dialog, provide the URL to your Simularium file
+                                and choose Load.
+                            </li>
+                            <ul>
+                                <li>
+                                    If your file uses geometry files, like .obj
+                                    or .pdb files, make sure you&apos;ve
+                                    provided the full public URL to the geometry
+                                    files in your .simularium file.
+                                </li>
+                            </ul>
+                            <li>
+                                Once the file is loaded, you can copy the page
+                                URL and share this link with collaborators or
+                                post it on your website so that others can
+                                interactively view your results.
+                            </li>
+                        </ol>
+                    </ul>
+                    <h1 id="browser-support">Browser support</h1>
+                    <ul>
+                        <li>
+                            Currently, Simularium supports Firefox, Chrome, and
+                            Edge. Some features may not work on other browsers.
+                        </li>
+                        <li>
+                            If using Safari on a Mac, please enable WebGL 2.0 by
+                            choosing Develop &gt; Experimental Features and
+                            enabling &quot;WebGL 2.0&quot; (If you do not have a
+                            Develop menu in your menu bar, please first choose
+                            Safari &gt; Preferences &gt; Advanced and enable
+                            &quot;Show Develop menu in menu bar&quot;.) Then
+                            please reload the viewer.
+                        </li>
+                    </ul>
+                </div>
             </Content>
             <Footer />
         </>

--- a/src/components/TutorialPage/style.css
+++ b/src/components/TutorialPage/style.css
@@ -5,12 +5,6 @@
     font-size: 18px;
 }
 
-@media screen and (max-width: 1200px) {
-    .content {
-        max-width: 1010px;
-    }
-}
-
 .text {
     max-width: 1200px;
     margin: auto;

--- a/src/components/TutorialPage/style.css
+++ b/src/components/TutorialPage/style.css
@@ -2,8 +2,13 @@
     display: block;
     margin: auto;
     padding: 2em;
-    max-width: 1010px;
     font-size: 18px;
+}
+
+@media screen and (max-width: 1200px) {
+    .content {
+        max-width: 1010px;
+    }
 }
 
 .intro {

--- a/src/components/TutorialPage/style.css
+++ b/src/components/TutorialPage/style.css
@@ -2,8 +2,18 @@
     display: block;
     margin: auto;
     padding: 2em;
-    max-width: 1010px;
     font-size: 18px;
+}
+
+@media screen and (max-width: 1200px) {
+    .content {
+        max-width: 1010px;
+    }
+}
+
+.text {
+    max-width: 1200px;
+    margin: auto;
 }
 
 .intro {

--- a/src/components/TutorialPage/style.css
+++ b/src/components/TutorialPage/style.css
@@ -11,6 +11,11 @@
     }
 }
 
+.text {
+    max-width: 1200px;
+    margin: auto;
+}
+
 .intro {
     margin-top: 1.5em;
     margin-bottom: 1.5em;

--- a/src/components/TutorialPage/style.css
+++ b/src/components/TutorialPage/style.css
@@ -2,18 +2,8 @@
     display: block;
     margin: auto;
     padding: 2em;
+    max-width: 1010px;
     font-size: 18px;
-}
-
-@media screen and (max-width: 1200px) {
-    .content {
-        max-width: 1010px;
-    }
-}
-
-.text {
-    max-width: 1200px;
-    margin: auto;
 }
 
 .intro {

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import * as React from "react";
 import { Collapse } from "antd";
 
 import visualGlossary from "../../constants/visual-glossary";
@@ -26,22 +26,10 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
 });
 
 const VisualGlossary = (): JSX.Element => {
-    const [isScreenWide, setIsScreenWide] = useState(
-        window.matchMedia("(min-width: 1622px)").matches
-    );
-
-    // NOTE: Currently this doesn't do anything... defaultActiveKey seems to only
-    // matter at initial page load...
-    useEffect(() => {
-        window
-            .matchMedia("(min-width: 1622px)")
-            .addEventListener("change", (e) => setIsScreenWide(e.matches));
-    }, []);
-
     return (
         <div className={styles.container}>
             <img src={visualGlossaryImage} />
-            <Collapse defaultActiveKey={isScreenWide ? "1" : []}>
+            <Collapse>
                 <Collapse.Panel header="Visual Glossary Key" key="1">
                     <ol className={styles.topLevelList}>
                         {renderGlossaryItems}

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -26,22 +26,26 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
 });
 
 const VisualGlossary = (): JSX.Element => {
-    const [isScreenWide, setIsScreenWide] = useState(
-        window.matchMedia("(min-width: 1622px)").matches
-    );
+    const wideScreenMinWidth = "1622px";
 
-    // NOTE: Currently this doesn't do anything... defaultActiveKey seems to only
-    // matter at initial page load...
+    // Lay out image and legend side-by-side when screen is wide enough
+    const [isScreenWide, setIsScreenWide] = useState(
+        window.matchMedia(`(min-width: ${wideScreenMinWidth})`).matches
+    );
     useEffect(() => {
         window
-            .matchMedia("(min-width: 1622px)")
+            .matchMedia(`(min-width: ${wideScreenMinWidth})`)
             .addEventListener("change", (e) => setIsScreenWide(e.matches));
     }, []);
+
+    // Legend box should be collapsed by default when underneath image
+    // and always in an open state when next to image
+    const collapseProps = isScreenWide && { activeKey: "1" };
 
     return (
         <div className={styles.container}>
             <img src={visualGlossaryImage} />
-            <Collapse defaultActiveKey={isScreenWide ? "1" : []}>
+            <Collapse {...collapseProps}>
                 <Collapse.Panel header="Visual Glossary Key" key="1">
                     <ol className={styles.topLevelList}>
                         {renderGlossaryItems}

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState, useEffect } from "react";
 import { Collapse } from "antd";
 
 import visualGlossary from "../../constants/visual-glossary";
@@ -26,10 +26,20 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
 });
 
 const VisualGlossary = (): JSX.Element => {
+    const [isScreenWide, setIsScreenWide] = useState(
+        window.matchMedia("(min-width: 1650px)").matches
+    );
+
+    useEffect(() => {
+        window
+            .matchMedia("(min-width: 1650px)")
+            .addEventListener("change", (e) => setIsScreenWide(e.matches));
+    }, []);
+
     return (
         <div className={styles.container}>
             <img src={visualGlossaryImage} />
-            <Collapse>
+            <Collapse defaultActiveKey={isScreenWide ? "1" : []}>
                 <Collapse.Panel header="Visual Glossary Key" key="1">
                     <ol className={styles.topLevelList}>
                         {renderGlossaryItems}

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -26,20 +26,26 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
 });
 
 const VisualGlossary = (): JSX.Element => {
-    const [isScreenWide, setIsScreenWide] = useState(
-        window.matchMedia("(min-width: 1650px)").matches
+    const [activeKey, setActiveKey] = useState(
+        window.matchMedia("(min-width: 1650px)").matches ? "1" : []
     );
 
     useEffect(() => {
         window
             .matchMedia("(min-width: 1650px)")
-            .addEventListener("change", (e) => setIsScreenWide(e.matches));
+            .addEventListener("change", (e) => {
+                if (e.matches) {
+                    setActiveKey("1");
+                } else {
+                    setActiveKey([]);
+                }
+            });
     }, []);
 
     return (
         <div className={styles.container}>
             <img src={visualGlossaryImage} />
-            <Collapse defaultActiveKey={isScreenWide ? "1" : []}>
+            <Collapse activeKey={activeKey}>
                 <Collapse.Panel header="Visual Glossary Key" key="1">
                     <ol className={styles.topLevelList}>
                         {renderGlossaryItems}

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -26,26 +26,20 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
 });
 
 const VisualGlossary = (): JSX.Element => {
-    const [activeKey, setActiveKey] = useState(
-        window.matchMedia("(min-width: 1650px)").matches ? "1" : []
+    const [isScreenWide, setIsScreenWide] = useState(
+        window.matchMedia("(min-width: 1650px)").matches
     );
 
     useEffect(() => {
         window
             .matchMedia("(min-width: 1650px)")
-            .addEventListener("change", (e) => {
-                if (e.matches) {
-                    setActiveKey("1");
-                } else {
-                    setActiveKey([]);
-                }
-            });
+            .addEventListener("change", (e) => setIsScreenWide(e.matches));
     }, []);
 
     return (
         <div className={styles.container}>
             <img src={visualGlossaryImage} />
-            <Collapse activeKey={activeKey}>
+            <Collapse defaultActiveKey={isScreenWide ? "1" : []}>
                 <Collapse.Panel header="Visual Glossary Key" key="1">
                     <ol className={styles.topLevelList}>
                         {renderGlossaryItems}

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -27,12 +27,14 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
 
 const VisualGlossary = (): JSX.Element => {
     const [isScreenWide, setIsScreenWide] = useState(
-        window.matchMedia("(min-width: 1650px)").matches
+        window.matchMedia("(min-width: 1622px)").matches
     );
 
+    // NOTE: Currently this doesn't do anything... defaultActiveKey seems to only
+    // matter at initial page load...
     useEffect(() => {
         window
-            .matchMedia("(min-width: 1650px)")
+            .matchMedia("(min-width: 1622px)")
             .addEventListener("change", (e) => setIsScreenWide(e.matches));
     }, []);
 

--- a/src/components/VisualGlossary/index.tsx
+++ b/src/components/VisualGlossary/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState, useEffect } from "react";
 import { Collapse } from "antd";
 
 import visualGlossary from "../../constants/visual-glossary";
@@ -26,10 +26,22 @@ const renderGlossaryItems = visualGlossary.map((item: VisualGlossaryItem) => {
 });
 
 const VisualGlossary = (): JSX.Element => {
+    const [isScreenWide, setIsScreenWide] = useState(
+        window.matchMedia("(min-width: 1622px)").matches
+    );
+
+    // NOTE: Currently this doesn't do anything... defaultActiveKey seems to only
+    // matter at initial page load...
+    useEffect(() => {
+        window
+            .matchMedia("(min-width: 1622px)")
+            .addEventListener("change", (e) => setIsScreenWide(e.matches));
+    }, []);
+
     return (
         <div className={styles.container}>
             <img src={visualGlossaryImage} />
-            <Collapse>
+            <Collapse defaultActiveKey={isScreenWide ? "1" : []}>
                 <Collapse.Panel header="Visual Glossary Key" key="1">
                     <ol className={styles.topLevelList}>
                         {renderGlossaryItems}

--- a/src/components/VisualGlossary/style.css
+++ b/src/components/VisualGlossary/style.css
@@ -1,11 +1,3 @@
-.container {
-    display: flex;
-    align-items: flex-start;
-    flex-wrap: wrap;
-    max-width: fit-content;
-    margin: auto;
-}
-
 .container img {
     max-width: 800px;
     display: block;
@@ -15,9 +7,11 @@
 }
 
 .container :global(.ant-collapse) {
-    width: 750px;
+    max-width: 750px;
     display: block;
-    margin: 1em auto 2em auto;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2em;
     background-color: var(--light-theme-background-purple);
     border: transparent;
     border-radius: 3px;
@@ -33,8 +27,6 @@
     background-color: var(--light-theme-background-off-white);
     font-size: 16px;
     border: none;
-    height: 348px;
-    overflow: scroll;
 }
 
 .topLevelList > li {

--- a/src/components/VisualGlossary/style.css
+++ b/src/components/VisualGlossary/style.css
@@ -33,7 +33,7 @@
     background-color: var(--light-theme-background-off-white);
     font-size: 16px;
     border: none;
-    height: 423px;
+    height: 348px;
     overflow: scroll;
 }
 

--- a/src/components/VisualGlossary/style.css
+++ b/src/components/VisualGlossary/style.css
@@ -1,3 +1,9 @@
+.container {
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
 .container img {
     max-width: 800px;
     display: block;
@@ -9,9 +15,7 @@
 .container :global(.ant-collapse) {
     max-width: 750px;
     display: block;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 2em;
+    margin: 1.5em auto 2em auto;
     background-color: var(--light-theme-background-purple);
     border: transparent;
     border-radius: 3px;
@@ -27,6 +31,8 @@
     background-color: var(--light-theme-background-off-white);
     font-size: 16px;
     border: none;
+    height: 400px;
+    overflow: scroll;
 }
 
 .topLevelList > li {

--- a/src/components/VisualGlossary/style.css
+++ b/src/components/VisualGlossary/style.css
@@ -2,6 +2,8 @@
     display: flex;
     align-items: flex-start;
     flex-wrap: wrap;
+    max-width: fit-content;
+    margin: auto;
 }
 
 .container img {
@@ -13,9 +15,9 @@
 }
 
 .container :global(.ant-collapse) {
-    max-width: 750px;
+    width: 750px;
     display: block;
-    margin: 1.5em auto 2em auto;
+    margin: 1em auto 2em auto;
     background-color: var(--light-theme-background-purple);
     border: transparent;
     border-radius: 3px;
@@ -31,7 +33,7 @@
     background-color: var(--light-theme-background-off-white);
     font-size: 16px;
     border: none;
-    height: 400px;
+    height: 423px;
     overflow: scroll;
 }
 

--- a/src/components/VisualGlossary/style.css
+++ b/src/components/VisualGlossary/style.css
@@ -15,7 +15,7 @@
 }
 
 .container :global(.ant-collapse) {
-    width: 750px;
+    width: 740px;
     display: block;
     margin: 1em auto 2em auto;
     background-color: var(--light-theme-background-purple);
@@ -33,7 +33,7 @@
     background-color: var(--light-theme-background-off-white);
     font-size: 16px;
     border: none;
-    height: 348px;
+    height: 417px;
     overflow: scroll;
 }
 

--- a/src/components/VisualGlossary/style.css
+++ b/src/components/VisualGlossary/style.css
@@ -1,3 +1,11 @@
+.container {
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    max-width: fit-content;
+    margin: auto;
+}
+
 .container img {
     max-width: 800px;
     display: block;
@@ -7,11 +15,9 @@
 }
 
 .container :global(.ant-collapse) {
-    max-width: 750px;
+    width: 750px;
     display: block;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 2em;
+    margin: 1em auto 2em auto;
     background-color: var(--light-theme-background-purple);
     border: transparent;
     border-radius: 3px;
@@ -27,6 +33,8 @@
     background-color: var(--light-theme-background-off-white);
     font-size: 16px;
     border: none;
+    height: 348px;
+    overflow: scroll;
 }
 
 .topLevelList > li {

--- a/src/constants/visual-glossary.ts
+++ b/src/constants/visual-glossary.ts
@@ -7,9 +7,16 @@ const visualGlossary: VisualGlossaryItem[] = [
             "Use this menu to choose an example model to view, or to select a file from a public cloud URL or from your local computer. You can also load a file locally from your computer by dragging it into the viewport.",
     },
     {
-        label: "CLICK TO SELECT & FOLLOW ANY OBJECT",
-        description:
-            "Left mouse clicking on any object in the 3D viewport will trigger the camera to point at it and to move to a helpful viewing distance. The camera will continue to Follow that object (outlined in bright green) until another another is selected, or all objects are deselected by clicking on an empty space in the viewport's background. It's easiest to pause the playback before attempting to CLICK on an object to follow.",
+        label: "CAMERA CONTROLS, from top to bottom:",
+        description: "",
+        bulletItems: [
+            "ROTATE: When this mode is active, click and drag to rotate the view in 3D. This mode is active by default.",
+            "PAN: When this mode is active, click and drag to pan around the view.",
+            "FOCUS: When this mode is active, the selected agent becomes the camera target and gets centered in the view. This mode is active by default.",
+            "ZOOM IN: Move the camera in towards the camera’s current target (either the camera look at position by default, or a followed object).",
+            "ZOOM OUT: Move the camera away from the camera’s target.",
+            "RESET CAMERA: Reset the 3D camera to the default (original) position and orientation.",
+        ],
     },
     {
         label: "CAMERA CONTROLS, from top to bottom:",

--- a/src/constants/visual-glossary.ts
+++ b/src/constants/visual-glossary.ts
@@ -24,18 +24,6 @@ const visualGlossary: VisualGlossaryItem[] = [
         ],
     },
     {
-        label: "CAMERA CONTROLS, from top to bottom:",
-        description: "",
-        bulletItems: [
-            "ROTATE: When this mode is active, click and drag to rotate the view in 3D. This mode is active by default.",
-            "PAN: When this mode is active, click and drag to pan around the view.",
-            "FOCUS: When this mode is active, the selected agent becomes the camera target and gets centered in the view. This mode is active by default.",
-            "ZOOM IN: Move the camera in towards the camera’s current target (either the camera look at position by default, or a followed object).",
-            "ZOOM OUT: Move the camera away from the camera’s target.",
-            "RESET CAMERA: Reset the 3D camera to the default (original) position and orientation.",
-        ],
-    },
-    {
         label: "PLAYBACK CONTROLS, from left to right:",
         description: "",
         bulletItems: [

--- a/src/constants/visual-glossary.ts
+++ b/src/constants/visual-glossary.ts
@@ -7,6 +7,11 @@ const visualGlossary: VisualGlossaryItem[] = [
             "Use this menu to choose an example model to view, or to select a file from a public cloud URL or from your local computer. You can also load a file locally from your computer by dragging it into the viewport.",
     },
     {
+        label: "CLICK TO SELECT & FOLLOW ANY OBJECT",
+        description:
+            "Left mouse clicking on any object in the 3D viewport will trigger the camera to point at it and to move to a helpful viewing distance. The camera will continue to Follow that object (outlined in bright green) until another another is selected, or all objects are deselected by clicking on an empty space in the viewport's background. It's easiest to pause the playback before attempting to CLICK on an object to follow.",
+    },
+    {
         label: "CAMERA CONTROLS, from top to bottom:",
         description: "",
         bulletItems: [


### PR DESCRIPTION
Problem
=======
It's hard to look at the visual glossary image and its legend at the same time with the current layout.

<img width="2070" alt="image" src="https://user-images.githubusercontent.com/12690133/153691437-a71a16ac-be45-45c3-87b5-df8ed339949d.png">


Closes #167 

Solution
========
* Constrain the legend box's height and add a scroll bar inside it
* Place the image and the legend side-by-side when the browser window is wide enough
* Place the legend below the image when the browser window is not wide enough

#### Details
* The above layouts switch back and forth dynamically as the user resizes the window
* On page load, if the screen is not wide enough for side-by-side, the legend box is collapsed by default so that the user can see there is more content below the fold
* When the screen is wide enough and the image and legend are side-by-side, the legend box is always in an open state (can't collapse it)

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Go to Help -> Quick start
3. Check out the visual glossary, try resizing your window, and refreshing the page at different widths

Screenshots (optional):
-----------------------
### Wide screen
<img width="1809" alt="image" src="https://user-images.githubusercontent.com/12690133/153691669-d0da7cd5-6a33-4cb3-954a-24c830dbdb1a.png">

### Narrower screen
<img width="600" alt="image" src="https://user-images.githubusercontent.com/12690133/153691722-3e153ead-554e-4c25-95d9-7ac0d14c8da5.png">

<img width="600" alt="image" src="https://user-images.githubusercontent.com/12690133/153691715-b44a8b6d-9c44-4792-bcbd-003885948cfe.png">