### PR TITLE
Fix/current time is hard to read when number of decimal places keeps changing

### DIFF
--- a/src/components/PlaybackControls/style.css
+++ b/src/components/PlaybackControls/style.css
@@ -14,7 +14,6 @@
 
 .container :global(.ant-input-number input) {
     color: var(--dark-theme-btn-color);
-    text-align: center;
     padding: 0 3px;
 }
 


### PR DESCRIPTION
Problem
=======
The current time display in the playback controls is hard to read when the number of decimal places keeps changing:

![Feb-15-2022 13-17-10](https://user-images.githubusercontent.com/12690133/154150733-3b1a2e66-16ac-49ee-97ba-7e87931fb8ba.gif)

Solution
========
Left-align the current time value instead of centering it:

![Feb-15-2022 13-20-15](https://user-images.githubusercontent.com/12690133/154151138-fd3344d0-c762-4327-a564-913fdcf96f0a.gif)

@blairlyons brought this issue up again (issue has been mentioned before but we never discussed solutions) and this was the simplest solution I could think of.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue) - Actually this is more like a design change, but it feels like a bug fix
