### PR TITLE
fix horizontal scroll

### DIFF
--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -24,37 +24,43 @@ const LandingPage = (): JSX.Element => {
         <React.Fragment>
             <Content className={styles.content}>
                 <div className={styles.panel}>
-                    <h1>Simularium {BetaTag}</h1>
-                    <h2>
-                        Share, visualize, & interrogate biological simulations
-                        online
-                    </h2>
-                    <br />
-                    <p>
-                        The Simularium Viewer makes it easy to share and
-                        interrogate interactive 3D visualizations of biological
-                        simulation trajectories and related plots directly in a
-                        web browser. Its primary goal is to facilitate
-                        collaborations among experimental and computational
-                        biologists by removing major challenges to sharing,
-                        accessing, and comparing simulation results.
-                    </p>
+                    <div className={styles.textContent}>
+                        <h1>Simularium {BetaTag}</h1>
+                        <h2>
+                            Share, visualize, & interrogate biological
+                            simulations online
+                        </h2>
+                        <br />
+                        <p>
+                            The Simularium Viewer makes it easy to share and
+                            interrogate interactive 3D visualizations of
+                            biological simulation trajectories and related plots
+                            directly in a web browser. Its primary goal is to
+                            facilitate collaborations among experimental and
+                            computational biologists by removing major
+                            challenges to sharing, accessing, and comparing
+                            simulation results.
+                        </p>
+                    </div>
                 </div>
+
                 <div
                     className={styles.trySimulariumPanel}
                     id="try-simularium-now"
                 >
-                    <h1>Try Simularium now</h1>
-                    <h2>View example simulations or load your own data</h2>
-                    <br />
-                    <p>
-                        With this first release we present the{" "}
-                        <i>Simularium Viewer</i>, an online visual analysis
-                        tool, which is one component of the larger Simularium
-                        platform. The Simularium Viewer provides an online
-                        application for visualizing simulation trajectories and
-                        related plots.
-                    </p>
+                    <div className={styles.textContent}>
+                        <h1>Try Simularium now</h1>
+                        <h2>View example simulations or load your own data</h2>
+                        <br />
+                        <p>
+                            With this first release we present the{" "}
+                            <i>Simularium Viewer</i>, an online visual analysis
+                            tool, which is one component of the larger
+                            Simularium platform. The Simularium Viewer provides
+                            an online application for visualizing simulation
+                            trajectories and related plots.
+                        </p>
+                    </div>
                     <div className={styles.cards}>
                         {TRAJECTORIES.slice(0, NUM_CARDS_PER_ROW - 1).map(
                             (trajectory) => {
@@ -78,140 +84,154 @@ const LandingPage = (): JSX.Element => {
                             }
                         )}
                     </div>
-                    <div className={styles.caption}>
-                        Click on any of the examples above to interact with
-                        example trajectories from various types of previously
-                        published simulations.
+                    <div className={styles.textContent}>
+                        <div className={styles.caption}>
+                            Click on any of the examples above to interact with
+                            example trajectories from various types of
+                            previously published simulations.
+                        </div>
+                        <p>
+                            Simularium v1.0 allows you to interact with
+                            precalculated simulation results &mdash; including
+                            your own results{" "}
+                            <a href={`${TUTORIAL_PATHNAME}#convert-your-data`}>
+                                converted
+                            </a>{" "}
+                            into the Simularium file format (JSON). The
+                            Simularium Viewer uses advanced rendering techniques
+                            developed by{" "}
+                            <a href="https://www.cg.tuwien.ac.at/research/publications/2015/cellVIEW_2015/">
+                                Le Muzic et al. (2015)
+                            </a>{" "}
+                            and{" "}
+                            <a href="https://ieeexplore.ieee.org/document/8017635">
+                                Mindek et al. (2017)
+                            </a>{" "}
+                            to enable meaningful interpretation of spatial
+                            relationships among thousands of moving components.
+                            Users can import a trajectory file (JSON format)
+                            from their computer, or they can stream provided
+                            examples by choosing one from the <i>Load model</i>{" "}
+                            dropdown or by clicking on a card above. Future
+                            versions of Simularium will allow you to modify,
+                            run, and even create simulations.
+                        </p>
+                        <img
+                            className={styles.image}
+                            alt="A flowchart summarizing how Simularium currently works"
+                            src={flowchartImg}
+                        />
+                        <img
+                            className={styles.imageBottom}
+                            alt="Illustrations of different agent representation options"
+                            src={agentRepOptionsImg}
+                        />
+                        <p>Current object representation options:</p>
+                        <ul>
+                            <li>
+                                Spheres: by default, each agent in a scene is
+                                represented as a single sphere
+                            </li>
+                            <li>
+                                Mesh surfaces: represent each agent as a mesh
+                                file, e.g. coarse molecular surfaces
+                            </li>
+                            <li>
+                                Multi-sphere: provide Protein Databank .pdb
+                                files
+                            </li>
+                            <li>
+                                Line representations for fibers, filaments, or
+                                bonds
+                            </li>
+                        </ul>
+                        <p>Planned for future:</p>
+                        <ul>
+                            <li>
+                                Volume rendering for RDME or PDE-based
+                                simulation results
+                            </li>
+                            <li>
+                                Support for .cif files and coarse-grain
+                                sphereTree files for multi-sphere rendering
+                            </li>
+                        </ul>
                     </div>
-                    <p>
-                        Simularium v1.0 allows you to interact with
-                        precalculated simulation results &mdash; including your
-                        own results{" "}
-                        <a href={`${TUTORIAL_PATHNAME}#convert-your-data`}>
-                            converted
-                        </a>{" "}
-                        into the Simularium file format (JSON). The Simularium
-                        Viewer uses advanced rendering techniques developed by{" "}
-                        <a href="https://www.cg.tuwien.ac.at/research/publications/2015/cellVIEW_2015/">
-                            Le Muzic et al. (2015)
-                        </a>{" "}
-                        and{" "}
-                        <a href="https://ieeexplore.ieee.org/document/8017635">
-                            Mindek et al. (2017)
-                        </a>{" "}
-                        to enable meaningful interpretation of spatial
-                        relationships among thousands of moving components.
-                        Users can import a trajectory file (JSON format) from
-                        their computer, or they can stream provided examples by
-                        choosing one from the <i>Load model</i> dropdown or by
-                        clicking on a card above. Future versions of Simularium
-                        will allow you to modify, run, and even create
-                        simulations.
-                    </p>
-                    <img
-                        className={styles.image}
-                        alt="A flowchart summarizing how Simularium currently works"
-                        src={flowchartImg}
-                    />
-                    <img
-                        className={styles.imageBottom}
-                        alt="Illustrations of different agent representation options"
-                        src={agentRepOptionsImg}
-                    />
-                    <p>Current object representation options:</p>
-                    <ul>
-                        <li>
-                            Spheres: by default, each agent in a scene is
-                            represented as a single sphere
-                        </li>
-                        <li>
-                            Mesh surfaces: represent each agent as a mesh file,
-                            e.g. coarse molecular surfaces
-                        </li>
-                        <li>
-                            Multi-sphere: provide Protein Databank .pdb files
-                        </li>
-                        <li>
-                            Line representations for fibers, filaments, or bonds
-                        </li>
-                    </ul>
-                    <p>Planned for future:</p>
-                    <ul>
-                        <li>
-                            Volume rendering for RDME or PDE-based simulation
-                            results
-                        </li>
-                        <li>
-                            Support for .cif files and coarse-grain sphereTree
-                            files for multi-sphere rendering
-                        </li>
-                    </ul>
                 </div>
                 <div className={styles.panel}>
-                    <h1>Connect with us</h1>
-                    <h2>
-                        Receive updates & technical support, or provide feedback
-                    </h2>
-                    <br />
-                    <p>
-                        We are collecting user feedback to improve this
-                        application. To find tutorials, seek technical support,
-                        report bugs or request features, use the <i>Help</i>{" "}
-                        menu found in the upper right corner of this website.
-                        Please{" "}
-                        {/* TODO: Change the URL to "mailto: simularium@alleninstitute.org" when that email address is ready */}
-                        <a href="http://allins.convio.net/site/PageServer?pagename=send_message_cs">
-                            contact us
-                        </a>{" "}
-                        if you have ideas for potential collaborations, or want
-                        to be alerted to major updates.
-                    </p>
+                    <div className={styles.textContent}>
+                        <h1>Connect with us</h1>
+                        <h2>
+                            Receive updates & technical support, or provide
+                            feedback
+                        </h2>
+                        <br />
+                        <p>
+                            We are collecting user feedback to improve this
+                            application. To find tutorials, seek technical
+                            support, report bugs or request features, use the{" "}
+                            <i>Help</i> menu found in the upper right corner of
+                            this website. Please{" "}
+                            {/* TODO: Change the URL to "mailto: simularium@alleninstitute.org" when that email address is ready */}
+                            <a href="http://allins.convio.net/site/PageServer?pagename=send_message_cs">
+                                contact us
+                            </a>{" "}
+                            if you have ideas for potential collaborations, or
+                            want to be alerted to major updates.
+                        </p>
+                    </div>
                 </div>
                 <div className={styles.futureSimulariumPanel}>
-                    <h1>Future plans for Simularium</h1>
-                    <h2>
-                        Create, modify, run, experiment, share, interoperate, &
-                        grow as a community
-                    </h2>
-                    <br />
-                    <p>
-                        In the next phase of its development, Simularium will
-                        enable users to modify simulation parameters for
-                        provided models through the web-based interface, to run
-                        the modified simulations on the cloud, and to analyze
-                        the results. Simularium currently supports{" "}
-                        <a href={CYTOSIM_URL}>
-                            <i>CytoSim</i>
-                        </a>{" "}
-                        and{" "}
-                        <a href={READDY_URL}>
-                            <i>ReaDDy</i>
-                        </a>
-                        . We plan to wrap several published packages that can
-                        serve as templates for community development and to
-                        encourage growth of the system by providing a well-
-                        documented API for simulation engine integration.
-                    </p>
-                    <p>
-                        We are investigating the use of these types of
-                        simulations and the various simulation engines that
-                        generated them for use in building an integrated,
-                        mechanistic understanding of human cells. We will also
-                        work with educators at all levels of science teaching to
-                        integrate and test Simularium’s potential for use in
-                        active learning classroom/lab/homework activities.
-                    </p>
+                    <div className={styles.textContent}>
+                        <h1>Future plans for Simularium</h1>
+                        <h2>
+                            Create, modify, run, experiment, share,
+                            interoperate, & grow as a community
+                        </h2>
+                        <br />
+                        <p>
+                            In the next phase of its development, Simularium
+                            will enable users to modify simulation parameters
+                            for provided models through the web-based interface,
+                            to run the modified simulations on the cloud, and to
+                            analyze the results. Simularium currently supports{" "}
+                            <a href={CYTOSIM_URL}>
+                                <i>CytoSim</i>
+                            </a>{" "}
+                            and{" "}
+                            <a href={READDY_URL}>
+                                <i>ReaDDy</i>
+                            </a>
+                            . We plan to wrap several published packages that
+                            can serve as templates for community development and
+                            to encourage growth of the system by providing a
+                            well- documented API for simulation engine
+                            integration.
+                        </p>
+                        <p>
+                            We are investigating the use of these types of
+                            simulations and the various simulation engines that
+                            generated them for use in building an integrated,
+                            mechanistic understanding of human cells. We will
+                            also work with educators at all levels of science
+                            teaching to integrate and test Simularium’s
+                            potential for use in active learning
+                            classroom/lab/homework activities.
+                        </p>
+                    </div>
                 </div>
                 <div className={styles.panel}>
-                    <h1>Acknowledgments</h1>
-                    <h2>
-                        We&apos;d like to thank the following people for their
-                        contributions to Simularium
-                    </h2>
-                    <br />
-                    <ReactMarkdown className={styles.markdown}>
-                        {markdownProcessed}
-                    </ReactMarkdown>
+                    <div className={styles.textContent}>
+                        <h1>Acknowledgments</h1>
+                        <h2>
+                            We&apos;d like to thank the following people for
+                            their contributions to Simularium
+                        </h2>
+                        <br />
+                        <ReactMarkdown className={styles.markdown}>
+                            {markdownProcessed}
+                        </ReactMarkdown>
+                    </div>
                 </div>
             </Content>
             <Footer />

--- a/src/components/LandingPage/style.css
+++ b/src/components/LandingPage/style.css
@@ -37,7 +37,7 @@
 
 /* Prevents content from horizontally spreading too much when browser window is very wide */
 .text-content {
-    max-width: 1100px;
+    max-width: 1010px;
     margin-left: auto;
     margin-right: auto;
 }

--- a/src/components/LandingPage/style.css
+++ b/src/components/LandingPage/style.css
@@ -36,8 +36,8 @@
 }
 
 /* Prevents content from horizontally spreading too much when browser window is very wide */
-.panel * {
-    max-width: 1010px;
+.text-content {
+    max-width: 1100px;
     margin-left: auto;
     margin-right: auto;
 }
@@ -47,7 +47,7 @@
     display: flex;
     flex-flow: row wrap;
     justify-content: center;
-    align-items: stretch;
+    margin: auto;
 }
 
 .cards > * {

--- a/src/components/LandingPage/style.css
+++ b/src/components/LandingPage/style.css
@@ -85,7 +85,6 @@
 
 .markdown {
     column-count: 2;
-    height: 540px;
 }
 
 .markdown > * {


### PR DESCRIPTION
Problem
=======
On chrome the landing page had horizontal scroll 

Solution
========
I first narrowed it down to the `max-width` setting on the text content, but it was just an arbitrary cutoff: If i set it to over 1040px, there was no scroll. 
So I finally figured out it was the markdown content, we had both column number and height set, which I guess caused an invisible overflow even though the text fit. 


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* Moved text content into it's own div
* Experimented with changing the max width settings
* Removed the height setting
* Revert max width to original setting 

Steps to Verify:
----------------
1. npm start
2. open in chrome
3. should not be able to horizontally scroll on landing page

Screenshots (optional):
-----------------------
**Before**:
<img width="761" alt="Screen Shot 2022-03-22 at 10 58 16 AM" src="https://user-images.githubusercontent.com/5170636/159557629-f410fca9-18ff-402a-9868-e5ffa48dd2bf.png">
NOTICE the text is longer in column 2
<img width="1146" alt="Screen Shot 2022-03-22 at 12 12 38 PM" src="https://user-images.githubusercontent.com/5170636/159557821-9bbc1724-0706-437b-bac2-bbfdd8ad8a35.png">
**After**:
<img width="1097" alt="Screen Shot 2022-03-22 at 12 12 25 PM" src="https://user-images.githubusercontent.com/5170636/159557961-89c6cabb-cc46-440f-8a56-d366780abbff.png">

