### PR TITLE
won't show time controls if there is no time range

### DIFF
--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -392,22 +392,24 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                         this.onTrajectoryFileInfoChanged
                     }
                 />
-                <PlaybackControls
-                    playHandler={this.startPlay}
-                    time={time}
-                    timeStep={timeStep}
-                    displayTimes={displayTimes}
-                    timeUnits={timeUnits}
-                    onTimeChange={this.skipToTime}
-                    pauseHandler={this.pause}
-                    prevHandler={this.playBackOne}
-                    nextHandler={this.playForwardOne}
-                    isPlaying={isPlaying}
-                    firstFrameTime={firstFrameTime}
-                    lastFrameTime={lastFrameTime}
-                    loading={isBuffering}
-                    isEmpty={status === VIEWER_EMPTY}
-                />
+                {firstFrameTime !== lastFrameTime && (
+                    <PlaybackControls
+                        playHandler={this.startPlay}
+                        time={time}
+                        timeStep={timeStep}
+                        displayTimes={displayTimes}
+                        timeUnits={timeUnits}
+                        onTimeChange={this.skipToTime}
+                        pauseHandler={this.pause}
+                        prevHandler={this.playBackOne}
+                        nextHandler={this.playForwardOne}
+                        isPlaying={isPlaying}
+                        firstFrameTime={firstFrameTime}
+                        lastFrameTime={lastFrameTime}
+                        loading={isBuffering}
+                        isEmpty={status === VIEWER_EMPTY}
+                    />
+                )}
                 <ScaleBar label={scaleBarLabel} />
                 <CameraControls
                     resetCamera={simulariumController.resetCamera}


### PR DESCRIPTION
Problem
=======
The cellPack files don't need playback controls when they're a single frame

Solution
========
Only show playback controls if the first time and last time are different 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. npm start
2. http://localhost:9001/viewer?trajUrl=https://www.dropbox.com/s/hhqrwp9bc8huufa/BloodPlasma.simularium?dl=0
3. Should not show a time bar
4. go to an example trajectory
5. time bar should be back

Screenshots (optional):
-----------------------
showing a cellpack file with no time bar 
<img width="597" alt="Screen Shot 2022-05-12 at 5 17 16 PM" src="https://user-images.githubusercontent.com/5170636/168188369-63d8716a-9a99-4e6f-b0be-1c793ad982fb.png">

