### PR TITLE
Feature/shorten names

### DIFF
--- a/src/components/CheckBoxTree/index.tsx
+++ b/src/components/CheckBoxTree/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Col, Row, Tooltip } from "antd";
+import { Col, Row, Typography } from "antd";
 import { ActionCreator } from "redux";
 import { CheckboxChangeEvent, CheckboxOptionType } from "antd/lib/checkbox";
 import { map, filter, isEmpty } from "lodash";
@@ -14,9 +14,11 @@ import SharedCheckbox from "../SharedCheckbox";
 import CheckboxTreeSubmenu from "../CheckboxTreeSubmenu";
 import TreeNode from "../TreeNode";
 import Checkbox from "../Checkbox";
-import { CHECKBOX_TYPE_STAR, LEFT_PANEL_TOOLTIP_COLOR } from "../../constants";
+import { CHECKBOX_TYPE_STAR } from "../../constants";
 import ColorSwatch from "../ColorSwatch";
 import NoTypeMappingText from "../NoTrajectoriesText/NoTypeMappingText";
+
+const { Text } = Typography;
 
 interface CheckBoxWithColor extends CheckboxOptionType {
     color: string;
@@ -235,19 +237,16 @@ class CheckBoxTree extends React.Component<CheckBoxTreeProps> {
                                               nodeData
                                           )}{" "}
                                     <ColorSwatch color={nodeData.color} />
-                                    <Tooltip
-                                        title={
-                                            nodeData.title.length > 20
-                                                ? nodeData.title
-                                                : null
-                                        }
-                                        placement="top"
-                                        color={LEFT_PANEL_TOOLTIP_COLOR}
+                                    <Text
+                                        style={{ maxWidth: 143 }}
+                                        ellipsis={{
+                                            tooltip: nodeData.title,
+                                        }}
                                     >
                                         <label className={styles.headerLabel}>
                                             {nodeData.title}
                                         </label>
-                                    </Tooltip>
+                                    </Text>
                                 </>
                             }
                             expandByDefault={!nodeData.color}

--- a/src/components/CheckBoxTree/index.tsx
+++ b/src/components/CheckBoxTree/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Col, Row } from "antd";
+import { Col, Row, Tooltip } from "antd";
 import { ActionCreator } from "redux";
 import { CheckboxChangeEvent, CheckboxOptionType } from "antd/lib/checkbox";
 import { map, filter, isEmpty } from "lodash";
@@ -14,7 +14,7 @@ import SharedCheckbox from "../SharedCheckbox";
 import CheckboxTreeSubmenu from "../CheckboxTreeSubmenu";
 import TreeNode from "../TreeNode";
 import Checkbox from "../Checkbox";
-import { CHECKBOX_TYPE_STAR } from "../../constants";
+import { CHECKBOX_TYPE_STAR, LEFT_PANEL_TOOLTIP_COLOR } from "../../constants";
 import ColorSwatch from "../ColorSwatch";
 import NoTypeMappingText from "../NoTrajectoriesText/NoTypeMappingText";
 
@@ -235,9 +235,19 @@ class CheckBoxTree extends React.Component<CheckBoxTreeProps> {
                                               nodeData
                                           )}{" "}
                                     <ColorSwatch color={nodeData.color} />
-                                    <label className={styles.headerLabel}>
-                                        {nodeData.title}
-                                    </label>
+                                    <Tooltip
+                                        title={
+                                            nodeData.title.length > 20
+                                                ? nodeData.title
+                                                : null
+                                        }
+                                        placement="top"
+                                        color={LEFT_PANEL_TOOLTIP_COLOR}
+                                    >
+                                        <label className={styles.headerLabel}>
+                                            {nodeData.title}
+                                        </label>
+                                    </Tooltip>
                                 </>
                             }
                             expandByDefault={!nodeData.color}

--- a/src/components/CheckBoxTree/style.css
+++ b/src/components/CheckBoxTree/style.css
@@ -12,14 +12,7 @@
 
 .header-label {
     margin-left: 8px;
-    max-width: 133px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-
-.ruler {
-    visibility: hidden;
-    white-space: nowrap;
+    max-width: 120px;
 }
 
 .checkbox-set {
@@ -91,4 +84,18 @@
 .star-icon::after {
     content: "\e902";
     color: var(--white-two);
+}
+
+.container :global(.ant-typography-ellipsis) {
+    color: var(--dark-theme-sidebar-text)
+}
+
+/* Tooltip styling  */
+/* Has to be global because it's at the bottom of the dom */
+:global(.ant-tooltip-inner){
+    background-color: var(--side-panel-tooltip);
+}
+
+:global(.ant-tooltip-arrow-content){
+    background-color:  var(--side-panel-tooltip);
 }

--- a/src/components/CheckBoxTree/style.css
+++ b/src/components/CheckBoxTree/style.css
@@ -12,6 +12,14 @@
 
 .header-label {
     margin-left: 8px;
+    max-width: 133px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+.ruler {
+    visibility: hidden;
+    white-space: nowrap;
 }
 
 .checkbox-set {

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -30,6 +30,7 @@
     --footer-text: var(--warm-gray);
     --footer-text-border-bottom: var(--greyish-brown);
     --footer-link: var(--blue);
+    --side-panel-tooltip: var(--charcoal-grey);
     --input-border-highlight: var(--baby-purple);
     --dark-theme-primary-color: var(--baby-purple);
     --dark-theme-body-bg: var(--black);


### PR DESCRIPTION
Problem
=======
Long agent titles mess up the side panel 

Solution
========
Truncated long text, using antd's ellipsis text feature


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
Before
<img width="354" alt="Screen Shot 2022-09-12 at 1 36 37 PM" src="https://user-images.githubusercontent.com/5170636/189753799-6ac35991-7061-4ade-b424-716f57df2422.png">
After
<img width="473" alt="Screen Shot 2022-09-12 at 1 33 39 PM" src="https://user-images.githubusercontent.com/5170636/189753750-58f97fbd-be5b-4547-8912-90801de22e19.png">

