### PR TITLE
Url Upload Auto Focus

### DIFF
--- a/src/components/LoadFileMenu/index.tsx
+++ b/src/components/LoadFileMenu/index.tsx
@@ -89,12 +89,6 @@ const LoadFileMenu = ({
                     From a URL
                 </Button>
             </Menu.Item>
-            {/* 
-            1. Putting UrlUploadModal inside Menu.Item causes keyboard bugs.
-               https://github.com/ant-design/ant-design/issues/34125
-            2. Conditionally rendering the modal this way instead of as a `visible` prop
-               forces it to re-render every time it is opened, resetting the form inside.
-            */}
             <Menu.Item key="local-file-upload">
                 <LocalFileUpload
                     clearSimulariumFile={clearSimulariumFile}
@@ -105,19 +99,32 @@ const LoadFileMenu = ({
             </Menu.Item>
         </Menu>
     );
-    if (isModalVisible) {
-        return <UrlUploadModal setIsModalVisible={setIsModalVisible} />;
-    }
+
     return (
-        <Dropdown overlay={menu} placement="bottomRight" disabled={isBuffering}>
-            <Button
-                className="ant-dropdown-link"
-                onClick={(e) => e.preventDefault()}
-                type="primary"
+        <>
+            <Dropdown
+                overlay={menu}
+                placement="bottomRight"
+                disabled={isBuffering}
             >
-                Load model {DownArrow}
-            </Button>
-        </Dropdown>
+                <Button
+                    className="ant-dropdown-link"
+                    onClick={(e) => e.preventDefault()}
+                    type="primary"
+                >
+                    Load model {DownArrow}
+                </Button>
+            </Dropdown>
+            {/* 
+            1. Putting UrlUploadModal inside Menu.Item causes keyboard bugs.
+               https://github.com/ant-design/ant-design/issues/34125
+            2. Conditionally rendering the modal this way instead of as a `visible` prop
+               forces it to re-render every time it is opened, resetting the form inside.
+            */}
+            {isModalVisible && (
+                <UrlUploadModal setIsModalVisible={setIsModalVisible} />
+            )}
+        </>
     );
 };
 

--- a/src/components/LoadFileMenu/index.tsx
+++ b/src/components/LoadFileMenu/index.tsx
@@ -95,9 +95,6 @@ const LoadFileMenu = ({
             2. Conditionally rendering the modal this way instead of as a `visible` prop
                forces it to re-render every time it is opened, resetting the form inside.
             */}
-            {isModalVisible && (
-                <UrlUploadModal setIsModalVisible={setIsModalVisible} />
-            )}
             <Menu.Item key="local-file-upload">
                 <LocalFileUpload
                     clearSimulariumFile={clearSimulariumFile}
@@ -108,7 +105,9 @@ const LoadFileMenu = ({
             </Menu.Item>
         </Menu>
     );
-
+    if (isModalVisible) {
+        return <UrlUploadModal setIsModalVisible={setIsModalVisible} />;
+    }
     return (
         <Dropdown overlay={menu} placement="bottomRight" disabled={isBuffering}>
             <Button

--- a/src/components/UrlUploadModal/index.tsx
+++ b/src/components/UrlUploadModal/index.tsx
@@ -35,7 +35,7 @@ const UrlUploadModal = ({
                 input.focus();
         }, 200);
         return () => clearInterval(inputFocus);
-    });
+    }, []);
 
     const loadTrajectory = (values: any) => {
         history.push(`${VIEWER_PATHNAME}?trajUrl=${values.url}`);

--- a/src/components/UrlUploadModal/index.tsx
+++ b/src/components/UrlUploadModal/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Form, Input, Modal } from "antd";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { TUTORIAL_PATHNAME, VIEWER_PATHNAME } from "../../routes";

--- a/src/components/UrlUploadModal/index.tsx
+++ b/src/components/UrlUploadModal/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Form, Input, Modal } from "antd";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { TUTORIAL_PATHNAME, VIEWER_PATHNAME } from "../../routes";
@@ -20,6 +20,23 @@ const UrlUploadModal = ({
         setIsModalVisible(false);
     };
 
+    //forces focus on input field when modal is opened
+    //if statement keeps tab targeting to the link
+    useEffect(() => {
+        const input = document.getElementsByClassName("ant-input")[
+            document.getElementsByClassName("ant-input").length - 1
+        ] as HTMLInputElement;
+        const inputFocus = setInterval(() => {
+            if (
+                input !== document.activeElement &&
+                document.activeElement &&
+                !document.activeElement.classList.contains("link")
+            )
+                input.focus();
+        }, 200);
+        return () => clearInterval(inputFocus);
+    });
+
     const loadTrajectory = (values: any) => {
         history.push(`${VIEWER_PATHNAME}?trajUrl=${values.url}`);
         location.reload();
@@ -30,6 +47,7 @@ const UrlUploadModal = ({
             We currently support public Dropbox, Google Drive, and Amazon S3
             links.{" "}
             <a
+                className="link"
                 href={`${TUTORIAL_PATHNAME}#share-a-link`}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/UrlUploadModal/index.tsx
+++ b/src/components/UrlUploadModal/index.tsx
@@ -21,8 +21,22 @@ const UrlUploadModal = ({
     };
 
     //forces focus on input field when modal is opened
-    //if statement keeps tab targeting to the link
+    //if statement keeps tab targeting to other parts of the modal
     useEffect(() => {
+        const closeBtn = document.getElementsByClassName("ant-modal-close")[
+            document.getElementsByClassName("ant-modal-close").length - 1
+        ] as HTMLButtonElement;
+        const link = document
+            .getElementsByClassName(styles.extraInfo)
+            [
+                document.getElementsByClassName(styles.extraInfo).length - 1
+            ].querySelector("a");
+        if (link && closeBtn) {
+            link.classList.add("tabbable");
+            link.tabIndex = 2;
+            closeBtn.classList.add("tabbable");
+            closeBtn.tabIndex = 4;
+        }
         const input = document.getElementsByClassName("ant-input")[
             document.getElementsByClassName("ant-input").length - 1
         ] as HTMLInputElement;
@@ -30,10 +44,10 @@ const UrlUploadModal = ({
             if (
                 input !== document.activeElement &&
                 document.activeElement &&
-                !document.activeElement.classList.contains("link")
+                !document.activeElement.classList.contains("tabbable")
             )
                 input.focus();
-        }, 200);
+        }, 400);
         return () => clearInterval(inputFocus);
     }, []);
 
@@ -47,7 +61,6 @@ const UrlUploadModal = ({
             We currently support public Dropbox, Google Drive, and Amazon S3
             links.{" "}
             <a
-                className="link"
                 href={`${TUTORIAL_PATHNAME}#share-a-link`}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -88,6 +101,7 @@ const UrlUploadModal = ({
                     ]}
                 >
                     <Input
+                        tabIndex={1}
                         allowClear
                         placeholder="https://.../example.simularium"
                         size="large"
@@ -97,6 +111,8 @@ const UrlUploadModal = ({
                 </Form.Item>
                 <Form.Item className={styles.submitButton}>
                     <Button
+                        tabIndex={3}
+                        className="tabbable"
                         type="default"
                         htmlType="submit"
                         disabled={!userInput}

--- a/src/components/UrlUploadModal/index.tsx
+++ b/src/components/UrlUploadModal/index.tsx
@@ -20,37 +20,6 @@ const UrlUploadModal = ({
         setIsModalVisible(false);
     };
 
-    //forces focus on input field when modal is opened
-    //if statement keeps tab targeting to other parts of the modal
-    useEffect(() => {
-        const closeBtn = document.getElementsByClassName("ant-modal-close")[
-            document.getElementsByClassName("ant-modal-close").length - 1
-        ] as HTMLButtonElement;
-        const link = document
-            .getElementsByClassName(styles.extraInfo)
-            [
-                document.getElementsByClassName(styles.extraInfo).length - 1
-            ].querySelector("a");
-        if (link && closeBtn) {
-            link.classList.add("tabbable");
-            link.tabIndex = 2;
-            closeBtn.classList.add("tabbable");
-            closeBtn.tabIndex = 4;
-        }
-        const input = document.getElementsByClassName("ant-input")[
-            document.getElementsByClassName("ant-input").length - 1
-        ] as HTMLInputElement;
-        const inputFocus = setInterval(() => {
-            if (
-                input !== document.activeElement &&
-                document.activeElement &&
-                !document.activeElement.classList.contains("tabbable")
-            )
-                input.focus();
-        }, 400);
-        return () => clearInterval(inputFocus);
-    }, []);
-
     const loadTrajectory = (values: any) => {
         history.push(`${VIEWER_PATHNAME}?trajUrl=${values.url}`);
         location.reload();
@@ -101,18 +70,15 @@ const UrlUploadModal = ({
                     ]}
                 >
                     <Input
-                        tabIndex={1}
                         allowClear
                         placeholder="https://.../example.simularium"
                         size="large"
                         onChange={handleUserInput}
-                        // autofocus FIXME: this doesn't work
+                        autoFocus={true}
                     />
                 </Form.Item>
                 <Form.Item className={styles.submitButton}>
                     <Button
-                        tabIndex={3}
-                        className="tabbable"
                         type="default"
                         htmlType="submit"
                         disabled={!userInput}

--- a/src/components/UrlUploadModal/style.css
+++ b/src/components/UrlUploadModal/style.css
@@ -4,6 +4,10 @@
     font-size: 14px;
 }
 
+.modal .extra-info a:focus {
+    opacity: 0.7;
+}
+
 .modal .submit-button {
     margin-bottom: 0px;
 }


### PR DESCRIPTION
Problem
=======
Solves #322
React, I believe, had a concurrent rendering issue causing 2 modals to be created, and the auto focus didn't know which to auto focus on

Solution
========
Moving the UrlUploadModal component to be on the same level as the menu instead of being rendered inside of the menu as the menu closes seems to fix the issue

Also added highlighting to the "Learn more" link when focused.

Steps to Verify:
----------------

Loading models still works and tab targeting to everything else still works.
Can't think of any other issues that would arise.
