### PR TITLE
push builds to new buckets

### DIFF
--- a/.github/workflows/ci-and-auto-deploy.yml
+++ b/.github/workflows/ci-and-auto-deploy.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 env: 
-  NODE_VERSION: '14.x'
+  NODE_VERSION: '16.x'
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 on: [push]
 
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{env.NODE_VERSION}}
       - run: npm ci
@@ -21,9 +21,9 @@ jobs:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{env.NODE_VERSION}}
       - run: npm ci
@@ -32,9 +32,9 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{env.NODE_VERSION}}
       - run: npm ci
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -72,15 +72,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{env.NODE_VERSION}}
       - run: npm ci 

--- a/.github/workflows/daily-new-viewer.yml
+++ b/.github/workflows/daily-new-viewer.yml
@@ -7,7 +7,7 @@ on:
     
 
 jobs:
-  build:
+  build-stable:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
 
       - name: Cache dependencies
         uses: actions/cache@v1
@@ -27,25 +27,31 @@ jobs:
             
       - run: npm ci
       - run: npm i @aics/simularium-viewer@latest
-      - run: npm run gh-build:stable
-      - run: npm i https://github.com/simularium/simularium-viewer#build
-      - run: npm run gh-build:dev
-      - name: Upload
-        uses: actions/upload-artifact@v3
-        with:
-          name: daily-build
-          path: gh-pages/
+      - run: npm run build
+      - name: Copy files to nightly-released bucket
+        run: aws s3 sync ./dist/ s3://nightly-released.simularium.allencell.org --delete
 
-  download-and-deploy:
+  build-dev:
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v3
-      - name: Display structure of downloaded files
-        run: ls -R
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./daily-build
+          node-version: "16.x"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+            
+
+      - run: npm ci
+      - run: npm i https://github.com/simularium/simularium-viewer#build
+      - run: npm run build
+      - name: Copy files to dev bucket
+        run: aws s3 sync ./dist/ s3://nightly-dev.simularium.allencell.org --delete

--- a/.github/workflows/nightly-new-viewer.yml
+++ b/.github/workflows/nightly-new-viewer.yml
@@ -1,5 +1,6 @@
 name: Nightly builds
-
+env: 
+  NODE_VERSION: '16.x'
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -12,15 +13,27 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: ${{env.NODE_VERSION}}
 
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
+        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
         with:
-          path: ~/.npm
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
@@ -35,21 +48,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+  
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
-
+          node-version: ${{env.NODE_VERSION}}
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
+        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
         with:
-          path: ~/.npm
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-            
-
       - run: npm ci
       - run: npm i https://github.com/simularium/simularium-viewer#build
       - run: npm run build

--- a/.github/workflows/nightly-new-viewer.yml
+++ b/.github/workflows/nightly-new-viewer.yml
@@ -1,4 +1,4 @@
-name: github pages
+name: Nightly builds
 
 on:
   schedule:

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -9,10 +9,16 @@
 <body>
     <ul>
         <li>
-            <a href="dev">App with viewer at development head</a>
+            <a href="https://nightly-dev.simularium.allencell.org"">Nightly Dev: App with viewer at development head</a>
         </li>
         <li>
-            <a href="stable">App with latest released stable viewer</a>
+            <a href="https://nightly-released.simularium.allencell.org">Nightly Stable: App with latest released stable viewer</a>
+        </li>
+        <li>
+            <a href="https://staging.simularium.allencell.org">Staging (may not have most updated viewer)</a>
+        </li>
+        <li>
+            <a href="https://simularium.allencell.org">Production</a>
         </li>
     </ul>
 </body>

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -9,7 +9,7 @@
 <body>
     <ul>
         <li>
-            <a href="https://nightly-dev.simularium.allencell.org"">Nightly Dev: App with viewer at development head</a>
+            <a href="https://nightly-dev.simularium.allencell.org">Nightly Dev: App with viewer at development head</a>
         </li>
         <li>
             <a href="https://nightly-released.simularium.allencell.org">Nightly Stable: App with latest released stable viewer</a>

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "license": "ISC",
     "scripts": {
         "start": "webpack serve --config ./webpack/webpack.config.js --env env=dev",
-        "gh-build": "cross-env GH_BUILD=true webpack --config ./webpack/webpack.config.js --env env=production",
-        "pregh-deploy": "npm run gh-build",
-        "gh-deploy": "gh-pages -d dist",
+        "gh-deploy": "gh-pages -d gh-pages",
         "build:staging": "cross-env NODE_ENV=staging webpack --config ./webpack/webpack.config.js  --env env=staging",
         "build": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js  --env env=production",
         "lint": "eslint src --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "scripts": {
         "start": "webpack serve --config ./webpack/webpack.config.js --env env=dev",
         "gh-build": "cross-env GH_BUILD=true webpack --config ./webpack/webpack.config.js --env env=production",
-        "gh-build:stable": "cross-env GH_BUILD=true webpack --config ./webpack/webpack.config.js --env env=production --env dest=gh-pages/stable",
-        "gh-build:dev": "cross-env GH_BUILD=true webpack --config ./webpack/webpack.config.js --env env=production --env dest=gh-pages/dev",
         "pregh-deploy": "npm run gh-build",
         "gh-deploy": "gh-pages -d dist",
         "build:staging": "cross-env NODE_ENV=staging webpack --config ./webpack/webpack.config.js  --env env=staging",


### PR DESCRIPTION
Problem
=======
we want to have a build with both our dev version of the viewer (what's on main), and our more resent stable release. 

Solution
========
We created two additional aws buckets to publish the app the same way we do production and staging. 
I changed the gh-pages page to link to all 4 version of the app we have: 
https://simularium.github.io/simularium-website/

I ran all the actions manually from my computer to have the first set of releases uploaded


## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. go [the gh-page](https://simularium.github.io/simularium-website/)
2. click on the different links

