### PR TITLE
Update "no trajectories" text

### DIFF
--- a/src/components/NoTrajectoriesText/index.tsx
+++ b/src/components/NoTrajectoriesText/index.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { ActionCreator } from "redux";
 
 import { RequestNetworkFileAction } from "../../state/trajectory/types";
-import { URL_PARAM_KEY_FILE_NAME, DATA_BUCKET_URL } from "../../constants";
+import { URL_PARAM_KEY_FILE_NAME } from "../../constants";
 import TRAJECTORIES from "../../constants/networked-trajectories";
 import { TrajectoryDisplayData } from "../../constants/interfaces";
 import { TUTORIAL_PATHNAME } from "../../routes";
@@ -27,33 +27,43 @@ const NoTrajectoriesText = ({
 
     return (
         <div className={styles.container}>
-            <h3>No trajectories loaded</h3>
+            <h3>Ways to get started:</h3>
             <p>
-                To view a simulation, either{" "}
-                <a
-                    href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
-                >
-                    download
-                </a>{" "}
-                our example data or{" "}
-                <a
-                    href={`${TUTORIAL_PATHNAME}#convert-your-data`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    convert
-                </a>{" "}
-                your own data, and then drag and drop the file onto this window.
-            </p>
-            <p>
-                <Link
-                    onClick={() => handleClick(exampleTrajectory)}
-                    to={{
-                        search: `?${URL_PARAM_KEY_FILE_NAME}=${exampleTrajectory.id}`,
-                    }}
-                >
-                    Load an example instead.
-                </Link>
+                <ol>
+                    <li>Drag and drop a .simularium file onto this window</li>
+                    <li>
+                        <Link
+                            onClick={() => handleClick(exampleTrajectory)}
+                            to={{
+                                search: `?${URL_PARAM_KEY_FILE_NAME}=${exampleTrajectory.id}`,
+                            }}
+                        >
+                            Load an example
+                        </Link>{" "}
+                        now or browse examples from the{" "}
+                        <a href="/#try-simularium-now">start page</a>
+                    </li>
+                    <li>
+                        Import common file types through the Load Model menu
+                        button, including:
+                        <ul>
+                            <li>Smoldyn</li>
+                            <li>Cytosim</li>
+                            <li>cellPACK</li>
+                            <li>SpringSaLaD</li>
+                        </ul>
+                    </li>
+                    <li>
+                        Convert other file types using{" "}
+                        <a
+                            href={`${TUTORIAL_PATHNAME}#convert-your-data`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            this tutorial
+                        </a>
+                    </li>
+                </ol>
             </p>
         </div>
     );

--- a/src/components/NoTrajectoriesText/style.css
+++ b/src/components/NoTrajectoriesText/style.css
@@ -2,7 +2,7 @@
     margin: 1em;
 }
 
-.container p, h3 {
+.container p, .container h3 {
     color: var(--dark-theme-sidebar-text);
     margin-bottom: 1.5em;
     font-size: 16px;
@@ -14,4 +14,8 @@
 
 .container p {
     font-weight: 200;
+}
+
+.container ul, .container ol {
+    padding-left: 20px;
 }


### PR DESCRIPTION
Resolve #386: update content that appears on the left panel when no trajectory is loaded to match [specification](https://xd.adobe.com/view/5f448466-eebd-4ad2-bdd8-314a55133403-0a17/screen/6066a8cf-b769-4c53-adae-873f9af9dc68), removing the option to download example data and adding a description of autoconversion.

### Screenshot
![image](https://user-images.githubusercontent.com/53030214/213317828-654e72e3-3d8d-4efe-8a7d-8ceb6eaa3933.png)
