### PR TITLE
add a default collapsed

### DIFF
--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -9,6 +9,7 @@ const { Sider } = Layout;
 import styles from "./style.css";
 
 interface SiderProps {
+    defaultCollapsed: boolean;
     type: string;
     onCollapse: (open: boolean) => void;
 }
@@ -19,7 +20,7 @@ interface SiderState {
 
 export default class SideBar extends React.Component<SiderProps, SiderState> {
     state: SiderState = {
-        collapsed: false,
+        collapsed: this.props.defaultCollapsed,
     };
 
     handleTriggerClick = () => {

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Layout } from "antd";
 import classNames from "classnames";
 
+import { MOBILE_CUTOFF } from "../../constants";
 import { PurpleArrow } from "../Icons";
 
 const { Sider } = Layout;
@@ -9,7 +10,6 @@ const { Sider } = Layout;
 import styles from "./style.css";
 
 interface SiderProps {
-    defaultCollapsed: boolean;
     type: string;
     onCollapse: (open: boolean) => void;
 }
@@ -20,7 +20,7 @@ interface SiderState {
 
 export default class SideBar extends React.Component<SiderProps, SiderState> {
     state: SiderState = {
-        collapsed: this.props.defaultCollapsed,
+        collapsed: window.matchMedia(MOBILE_CUTOFF).matches,
     };
 
     handleTriggerClick = () => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -47,3 +47,5 @@ export const USER_TRAJ_REDIRECTS = [
     "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_At_Ksp.simularium",
     "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_Above_Ksp.simularium",
 ];
+
+export const MOBILE_CUTOFF = "(max-width: 900px)";

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -203,6 +203,7 @@ class App extends React.Component<AppProps, AppState> {
             clearSimulariumFile,
             setError,
         } = this.props;
+        const isMobileScreen = window.matchMedia("(max-width: 900px)").matches;
         return (
             <Layout className={styles.container}>
                 <div ref={this.interactiveContent}>
@@ -217,7 +218,11 @@ class App extends React.Component<AppProps, AppState> {
                             setViewerStatus={setViewerStatus}
                             setError={setError}
                         />
-                        <SideBar onCollapse={this.onPanelCollapse} type="left">
+                        <SideBar
+                            onCollapse={this.onPanelCollapse}
+                            type="left"
+                            defaultCollapsed={isMobileScreen}
+                        >
                             <ModelPanel />
                         </SideBar>
                         <Content>
@@ -228,7 +233,11 @@ class App extends React.Component<AppProps, AppState> {
                                 />
                             )}
                         </Content>
-                        <SideBar onCollapse={this.onPanelCollapse} type="right">
+                        <SideBar
+                            onCollapse={this.onPanelCollapse}
+                            type="right"
+                            defaultCollapsed={isMobileScreen}
+                        >
                             <ResultsPanel />
                         </SideBar>
                     </Layout>

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -203,7 +203,6 @@ class App extends React.Component<AppProps, AppState> {
             clearSimulariumFile,
             setError,
         } = this.props;
-        const isMobileScreen = window.matchMedia("(max-width: 900px)").matches;
         return (
             <Layout className={styles.container}>
                 <div ref={this.interactiveContent}>
@@ -221,7 +220,6 @@ class App extends React.Component<AppProps, AppState> {
                         <SideBar
                             onCollapse={this.onPanelCollapse}
                             type="left"
-                            defaultCollapsed={isMobileScreen}
                         >
                             <ModelPanel />
                         </SideBar>
@@ -236,7 +234,6 @@ class App extends React.Component<AppProps, AppState> {
                         <SideBar
                             onCollapse={this.onPanelCollapse}
                             type="right"
-                            defaultCollapsed={isMobileScreen}
                         >
                             <ResultsPanel />
                         </SideBar>

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -56,6 +56,7 @@ import { AGENT_COLORS } from "./constants";
 import { DisplayTimes } from "./types";
 
 import styles from "./style.css";
+import { MOBILE_CUTOFF } from "../../constants";
 
 interface ViewerPanelProps {
     time: number;
@@ -147,7 +148,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             });
         }
 
-        if (window.matchMedia("(max-width: 900px)").matches) {
+        if (window.matchMedia(MOBILE_CUTOFF).matches) {
             Modal.warning({
                 title: "Small screens are not supported",
                 content:


### PR DESCRIPTION
Problem
=======
On mobile the app is pretty unusable because the panels are open by default and overlap each other. 

Blair has QR codes on her poster 

Solution
========
The `collapsed` state on the side panels is initialized based on the window size. This means that it's only set on load, it's not set as a listeners. So if a user did the strange thing of loading the app on their computer, and then make the browser window tiny, it won't auto close the panels unless they re-load at the smaller size

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1.`npm start`
2. make the screen mobile sized and reload
3. the panels should initialize to closed 
4. make the screen normal screen sized and reload
5. the panels should initialize to open

Screenshots (optional):
-----------------------
<img width="487" alt="Screen Shot 2023-02-16 at 4 12 25 PM" src="https://user-images.githubusercontent.com/5170636/219516609-e592bece-13f2-47ac-ae3e-befb8cf7e638.png">

