### PR TITLE
looping playback and tooltip styling

### DIFF
--- a/src/components/CheckBoxTree/style.css
+++ b/src/components/CheckBoxTree/style.css
@@ -89,13 +89,3 @@
 .container :global(.ant-typography-ellipsis) {
     color: var(--dark-theme-sidebar-text)
 }
-
-/* Tooltip styling  */
-/* Has to be global because it's at the bottom of the dom */
-:global(.ant-tooltip-inner){
-    background-color: var(--side-panel-tooltip);
-}
-
-:global(.ant-tooltip-arrow-content){
-    background-color:  var(--side-panel-tooltip);
-}

--- a/src/components/Icons/index.tsx
+++ b/src/components/Icons/index.tsx
@@ -9,6 +9,7 @@ import {
     PlusOutlined,
     MinusOutlined,
     HomeOutlined,
+    RetweetOutlined,
 } from "@ant-design/icons";
 
 import PurpleArrowPointingRight from "../../assets/open-arrow.svg";
@@ -27,6 +28,7 @@ export const GoBack = <ArrowLeftOutlined />;
 export const Reset = <HomeOutlined />;
 export const ZoomIn = <PlusOutlined />;
 export const ZoomOut = <MinusOutlined />;
+export const LoopOutlined = <RetweetOutlined />;
 
 export const PurpleArrow = <img src={PurpleArrowPointingRight} />;
 export const AicsLogo = <img src={AicsLogoWhite} style={{ width: "140px" }} />;
@@ -51,4 +53,5 @@ export default {
     ZoomIn,
     ZoomOut,
     BetaTag,
+    LoopOutlined,
 };

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useCallback, useState } from "react";
+import React, { KeyboardEvent, useState } from "react";
 import { Button, Slider, Tooltip, InputNumber } from "antd";
 import classNames from "classnames";
 import { compareTimes } from "@aics/simularium-viewer";

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useState } from "react";
+import React, { KeyboardEvent, useCallback, useState } from "react";
 import { Button, Slider, Tooltip, InputNumber } from "antd";
 import classNames from "classnames";
 import { compareTimes } from "@aics/simularium-viewer";
@@ -15,9 +15,11 @@ interface PlayBackProps {
     pauseHandler: () => void;
     prevHandler: () => void;
     nextHandler: () => void;
+    loopHandler: () => void;
     firstFrameTime: number;
     lastFrameTime: number;
     isPlaying: boolean;
+    isLooping: boolean;
     onTimeChange: (time: number) => void;
     loading: boolean;
     timeStep: number;
@@ -31,7 +33,9 @@ const PlayBackControls = ({
     playHandler,
     pauseHandler,
     prevHandler,
+    loopHandler,
     isPlaying,
+    isLooping,
     nextHandler,
     firstFrameTime,
     lastFrameTime,
@@ -187,7 +191,7 @@ const PlayBackControls = ({
                 value={time}
                 onChange={handleTimeChange}
                 onAfterChange={handleSliderMouseUp}
-                tooltip={{open : false}}
+                tooltip={{ open: false }}
                 className={[styles.slider, styles.item].join(" ")}
                 step={timeStep}
                 min={firstFrameTime}
@@ -210,6 +214,29 @@ const PlayBackControls = ({
                     {timeUnits ? timeUnits.name : "s"}
                 </span>
             </div>
+            <Tooltip
+                placement="top"
+                title={isLooping ? "Turn off looping" : "Turn on looping"}
+                color={TOOLTIP_COLOR}
+                arrowPointAtCenter
+            >
+                <Button
+                    className={
+                        isLooping
+                            ? btnClassNames
+                            : classNames([
+                                  styles.item,
+                                  styles.btn,
+                                  styles.removeBorder,
+                              ])
+                    }
+                    size="small"
+                    icon={Icons.LoopOutlined}
+                    onClick={loopHandler}
+                    loading={loading}
+                    disabled={isEmpty}
+                />
+            </Tooltip>
         </div>
     );
 };

--- a/src/components/PlaybackControls/style.css
+++ b/src/components/PlaybackControls/style.css
@@ -77,6 +77,7 @@
     padding: 1px 7px 4px 7px;
     border-radius: 3px;
     text-align: center;
+    margin-right: 4px;
 }
 
 .lastFrameTime {
@@ -94,4 +95,8 @@
 
 .step-forward::after {
     content: "\e907";
+}
+
+.remove-border{
+    border: none;
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,7 +5,7 @@ export const URL_PARAM_KEY_FILE_NAME = "trajFileName";
 export const URL_PARAM_KEY_USER_URL = "trajUrl";
 export const CHECKBOX_TYPE_STAR = "star";
 export type CHECKBOX_TYPE_STAR = typeof CHECKBOX_TYPE_STAR;
-export const TOOLTIP_COLOR = "#141219";
+export const TOOLTIP_COLOR = "#3B3649";
 export const LEFT_PANEL_TOOLTIP_COLOR = "#3b3649";
 export const LEFT_PANEL_TOOLTIP_DELAY = 1; // in seconds
 

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -307,8 +307,6 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             compareTimes(timeData.time, lastFrameTime, timeStep) === 0;
         if (atLastFrame && isLooping) {
             actions.push(changeTime(0));
-            actions.push(setBuffering(true));
-            actions.push(setIsPlaying(true));
             this.startPlay(0);
         } else if (atLastFrame) {
             this.pause();

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -244,11 +244,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
 
     public toggleLooping() {
         const { isLooping, setIsLooping } = this.props;
-        if (isLooping) {
-            setIsLooping(false);
-        } else {
-            setIsLooping(true);
-        }
+        setIsLooping(!isLooping);
     }
 
     public onTrajectoryFileInfoChanged(data: TrajectoryFileInfo) {
@@ -282,7 +278,6 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             timeStep,
             receiveTrajectory,
             setBuffering,
-            setIsPlaying,
             isLooping,
         } = this.props;
 

--- a/src/state/viewer/actions.ts
+++ b/src/state/viewer/actions.ts
@@ -5,6 +5,7 @@ import {
     SET_BUFFERING,
     SET_IS_PLAYING,
     SET_ERROR,
+    SET_IS_LOOPING,
 } from "./constants";
 import {
     ViewerStatus,
@@ -55,5 +56,12 @@ export function setIsPlaying(isPlaying: boolean): ToggleAction {
     return {
         payload: isPlaying,
         type: SET_IS_PLAYING,
+    };
+}
+
+export function setIsLooping(isLooping: boolean): ToggleAction {
+    return {
+        payload: isLooping,
+        type: SET_IS_LOOPING,
     };
 }

--- a/src/state/viewer/constants.ts
+++ b/src/state/viewer/constants.ts
@@ -9,8 +9,10 @@ export const DRAG_FILE_OVER = makeViewerConstant("drag-file-over");
 export const RESET_DRAG_FILE_OVER = makeViewerConstant("reset-drag-file-over");
 export const SET_BUFFERING = makeViewerConstant("set-buffering");
 export const SET_IS_PLAYING = makeViewerConstant("set-is-playing");
+export const SET_IS_LOOPING = makeViewerConstant("set-is-looping");
 
 export const VIEWER_EMPTY = "empty";
 export const VIEWER_LOADING = "loading";
 export const VIEWER_ERROR = "error";
 export const VIEWER_SUCCESS = "success";
+export const VIEWER_IMPORTING = "importing";

--- a/src/state/viewer/reducer.ts
+++ b/src/state/viewer/reducer.ts
@@ -12,6 +12,7 @@ import {
     SET_BUFFERING,
     SET_IS_PLAYING,
     VIEWER_ERROR,
+    SET_IS_LOOPING,
 } from "./constants";
 import {
     ViewerStateBranch,
@@ -28,6 +29,7 @@ export const initialState = {
     fileDraggedOver: false,
     isBuffering: false,
     isPlaying: false,
+    isLooping: false,
 };
 
 const actionToConfigMap: TypeToDescriptionMap = {
@@ -86,6 +88,14 @@ const actionToConfigMap: TypeToDescriptionMap = {
         perform: (state: ViewerStateBranch, action: ToggleAction) => ({
             ...state,
             isPlaying: action.payload,
+        }),
+    },
+    [SET_IS_LOOPING]: {
+        accepts: (action: AnyAction): action is ToggleAction =>
+            action.type === SET_IS_LOOPING,
+        perform: (state: ViewerStateBranch, action: ToggleAction) => ({
+            ...state,
+            isLooping: action.payload,
         }),
     },
 };

--- a/src/state/viewer/selectors/basic.ts
+++ b/src/state/viewer/selectors/basic.ts
@@ -6,3 +6,4 @@ export const getFileDraggedOver = (state: State) =>
     state.viewer.fileDraggedOver;
 export const getIsBuffering = (state: State) => state.viewer.isBuffering;
 export const getIsPlaying = (state: State) => state.viewer.isPlaying;
+export const getIsLooping = (state: State) => state.viewer.isLooping;

--- a/src/style.css
+++ b/src/style.css
@@ -116,7 +116,7 @@ use the :after pseduo selector to input the content.
 
 .ant-tooltip-inner,
 .ant-popover-inner {
-    border-radius: 3px;
-    font-weight: 300;
-    box-shadow: 2px 2px 3px black;
+    background: var(--charcoal-grey) 0% 0% no-repeat padding-box;
+    box-shadow: 0px 3px 4px var(--black);
+    opacity: 1;
 }


### PR DESCRIPTION
Problem:
=======
Users want to be able to loop simulation playback, tooltips across simularium have different styling.

Closes https://github.com/simularium/simularium-website/issues/298

NOTE: Initial feature branch was mistakenly branched from auto-conversion feature branch instead of main, leading to git mess. Deleted that and recreated this branch so commit history is compressed into one commit.

Solution:
=======
New feature (non-breaking change which adds functionality)

Gives users the ability to loop simulation playback, as well as setting primary global styling for tooltips.

Looping button was added to UI, clicking the button toggles a new piece of state in the viewer branch. Playback functions, icons, and tooltips respond to that state.

Styles were added/removed to make tooltips across the application have matching styling.

Steps to Verify:
=======
Load a simulation, find and click the looping icon in the playback controls, run a simulation and see if its starts over when it reaches the last frame.

Check styling on tooltips by hovering cursor over left panel checkboxes, playback controls, and home icon. Should match [design.](https://xd.adobe.com/view/75b6a3c8-f650-443b-bccc-d1fcd134a35e-20e5/screen/324d327c-ade5-4765-8c66-aa61db1feb4f/specs/)

Keyfiles:
=======
- UI elements added to PlaybackControls/index.tsx
- Looping state changes the standard suite of Redux files.
- ViewerPanel/index.tsx holds function toggleLooping to toggle looping state, and function receiveTimeChange which has the logic for looping playback.
