### PR TITLE
Feature/version info

### DIFF
--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -79,7 +79,7 @@ const HelpMenu = (): JSX.Element => {
                     setModalVisible(!modalVisible);
                 }}
             >
-                <>Version Info</>
+                <>Version info</>
             </Menu.Item>
         </Menu>
     );

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -77,7 +77,6 @@ const HelpMenu = (): JSX.Element => {
             <Menu.Item
                 key="version"
                 onClick={() => {
-                    console.log("firing");
                     setModalVisible(!modalVisible);
                 }}
             >

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -34,7 +34,6 @@ const HelpMenu = (): JSX.Element => {
 
     const menu = (
         <Menu theme="dark" className={styles.menu}>
-            {/* <VersionModal /> */}
             {modalVisible ? (
                 <VersionModal setModalVisible={setModalVisible} />
             ) : null}

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -13,6 +13,8 @@ import {
 
 import styles from "./style.css";
 
+import VersionModal from "../VersionModal";
+
 const HelpMenu = (): JSX.Element => {
     const location = useLocation();
     const tutorialLink =
@@ -27,8 +29,15 @@ const HelpMenu = (): JSX.Element => {
         ) : (
             <Link to={TUTORIAL_PATHNAME}>Quick start</Link>
         );
+
+    const [modalVisible, setModalVisible] = React.useState(false);
+
     const menu = (
         <Menu theme="dark" className={styles.menu}>
+            {/* <VersionModal /> */}
+            {modalVisible ? (
+                <VersionModal setModalVisible={setModalVisible} />
+            ) : null}
             <Menu.Item key="tutorial">{tutorialLink}</Menu.Item>
             <Menu.Item key="forum">
                 <a href={FORUM_URL} target="_blank" rel="noopener noreferrer">
@@ -65,6 +74,15 @@ const HelpMenu = (): JSX.Element => {
                     </a>
                 </Menu.Item>
             </Menu.SubMenu>
+            <Menu.Item
+                key="version"
+                onClick={() => {
+                    console.log("firing");
+                    setModalVisible(!modalVisible);
+                }}
+            >
+                <>Version Info</>
+            </Menu.Item>
         </Menu>
     );
 

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -34,9 +34,9 @@ const HelpMenu = (): JSX.Element => {
 
     const menu = (
         <Menu theme="dark" className={styles.menu}>
-            {modalVisible ? (
+            {modalVisible && (
                 <VersionModal setModalVisible={setModalVisible} />
-            ) : null}
+            )}
             <Menu.Item key="tutorial">{tutorialLink}</Menu.Item>
             <Menu.Item key="forum">
                 <a href={FORUM_URL} target="_blank" rel="noopener noreferrer">

--- a/src/components/HelpMenu/style.css
+++ b/src/components/HelpMenu/style.css
@@ -14,3 +14,7 @@
     right: 160px !important;
     left: auto !important;
 }
+
+.menu :global(.ant-dropdown-menu-item-active){
+    background-color: transparent !important;
+}

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -43,7 +43,7 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
                 Viewer:{" "}
                 <span className={styles.blueText}>
                     {" "}
-                    simulairum-viewer v{SIMULARIUM_VIEWER_VERSION}{" "}
+                    simularium-viewer v{SIMULARIUM_VIEWER_VERSION}{" "}
                 </span>
             </div>
         </CustomModal>

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -27,7 +27,7 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
             open
             footer={footerButton}
             centered
-            title="Version Info"
+            title="Version Information"
             width={425}
         >
             <div>

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -15,12 +15,11 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
     };
 
     const footerButton = (
-        <>
-            <Button type="primary" onClick={closeModal}>
-                Close
-            </Button>
-        </>
+        <Button type="primary" onClick={closeModal}>
+            Close
+        </Button>
     );
+
     return (
         <CustomModal
             className={styles.container}

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -21,7 +21,6 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
             </Button>
         </>
     );
-    console.log("VersionModal");
     return (
         <CustomModal
             className={styles.container}
@@ -48,8 +47,8 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
                     simulairum-viewer v{SIMULARIUM_VIEWER_VERSION}{" "}
                 </span>
             </div>
-            {/* TODO what should this content be */}
-            <span> Engine: not connected to server </span>
+            {/* TODO add enginge when we switch to Octopus?/}
+            {/* <span> Engine: not connected to server </span> */}
         </CustomModal>
     );
 };

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -46,8 +46,6 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
                     simulairum-viewer v{SIMULARIUM_VIEWER_VERSION}{" "}
                 </span>
             </div>
-            {/* TODO add enginge when we switch to Octopus?/}
-            {/* <span> Engine: not connected to server </span> */}
         </CustomModal>
     );
 };

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -1,0 +1,57 @@
+import { Button } from "antd";
+import React from "react";
+
+import CustomModal from "../CustomModal";
+
+import styles from "./style.css";
+
+interface VersionModalProps {
+    setModalVisible: (isModalVisible: boolean) => void;
+}
+
+const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
+    const closeModal = () => {
+        setModalVisible(false);
+    };
+
+    const footerButton = (
+        <>
+            <Button type="primary" onClick={closeModal}>
+                Close
+            </Button>
+        </>
+    );
+    console.log("VersionModal");
+    return (
+        <CustomModal
+            className={styles.container}
+            onCancel={closeModal}
+            open
+            footer={footerButton}
+            centered
+            title="Version Info"
+            width={425}
+        >
+            <div>
+                {" "}
+                Application:{" "}
+                <span className={styles.blueText}>
+                    {" "}
+                    simularium-website v{SIMULARIUM_WEBSITE_VERSION}{" "}
+                </span>
+            </div>
+            <div>
+                {" "}
+                Viewer:{" "}
+                <span className={styles.blueText}>
+                    {" "}
+                    simulairum-viewer v{SIMULARIUM_VIEWER_VERSION}{" "}
+                </span>
+            </div>
+            {/* TODO what should this content be */}
+            <span> Engine: not connected to server </span>
+        </CustomModal>
+    );
+};
+
+export default VersionModal;

--- a/src/components/VersionModal/style.css
+++ b/src/components/VersionModal/style.css
@@ -1,12 +1,18 @@
-
-.blue-text {
+.container .blue-text {
     color: var(--blue);
 }
 
-.container :global(.ant-modal-footer) {
-    background-color: var(--modal-content-bg);
+.container :global(.ant-modal-header) {
+    padding: 12px 24px;
+}
+.container :global(.ant-modal-title) {
+    font-weight: 400;
 }
 
 .container :global(.ant-modal-body) {
     padding: 12px 12px 0px 12px;
+}
+
+.container :global(.ant-modal-footer) {
+    background-color: var(--modal-content-bg);
 }

--- a/src/components/VersionModal/style.css
+++ b/src/components/VersionModal/style.css
@@ -1,0 +1,12 @@
+
+.blue-text {
+    color: var(--blue);
+}
+
+.container :global(.ant-modal-footer) {
+    background-color: var(--modal-content-bg);
+}
+
+.container :global(.ant-modal-body) {
+    padding: 12px 12px 0px 12px;
+}


### PR DESCRIPTION
Problem
=======
Mostly closes [#304](https://github.com/simularium/simularium-website/issues/304)
Leaving out Engine version for now, will revisit in Octopus era.

Change summary:
---------------
Opens a modal to display version info when help menu item is selected.

Steps to Verify:
----------------
Find 'Version Info' in help menu and open the modal.