### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,11 +63,12 @@ ___
 Run `npm update` to update dependencies, including simularium-viewer
 
 ### Daily builds
-[Viewer at development head](https://simularium.github.io/simularium-website/dev)
-[Latest released stable viewer](https://simularium.github.io/simularium-website/stable)
+- [Site with viewer at development head](https://simularium.github.io/simularium-website/dev)
+- [Site with latest released stable viewer](https://simularium.github.io/simularium-website/stable)
 
 #### Staging deployment
 Automatically builds from `main`
+- [Staging site](https://staging.simularium.allencell.org/)
 
 #### Production deployment
 1. Make a new version: `npm version [patch/minor/major]`


### PR DESCRIPTION
Problem
=======
We want to use gh-pages as a dev deployment but it was currently hosting a site that linked to the different development releases

Solution
========
Moved the links to CONTRIBUTING.md (they were mostly already there)

## Type of change
Please delete options that are not relevant.

* Documentation update
