### PR TITLE
change check for if a file is shareable

### DIFF
--- a/src/components/DownloadTrajectoryMenu/index.tsx
+++ b/src/components/DownloadTrajectoryMenu/index.tsx
@@ -3,23 +3,21 @@ import { Button, Tooltip } from "antd";
 import { ISimulariumFile } from "@aics/simularium-viewer/type-declarations";
 
 import { DATA_BUCKET_URL, TOOLTIP_COLOR } from "../../constants";
-import {
-    NetworkedSimFile,
-    LocalSimFile,
-    isNetworkSimFileInterface,
-} from "../../state/trajectory/types";
+import { NetworkedSimFile, LocalSimFile } from "../../state/trajectory/types";
 import { Download } from "../Icons";
 
 import styles from "./style.css";
 
 interface DownloadTrajectoryMenuProps {
     isBuffering: boolean;
+    isNetworkedFile: boolean;
     simulariumFile: LocalSimFile | NetworkedSimFile;
 }
 
 const DownloadTrajectoryMenu = ({
     isBuffering,
     simulariumFile,
+    isNetworkedFile,
 }: DownloadTrajectoryMenuProps): JSX.Element => {
     const fileIsLoaded = () => !!simulariumFile.name;
 
@@ -27,10 +25,11 @@ const DownloadTrajectoryMenu = ({
         if (!fileIsLoaded()) {
             return "";
         }
-        if (isNetworkSimFileInterface(simulariumFile)) {
+        if (isNetworkedFile) {
             return `${DATA_BUCKET_URL}/trajectory/${simulariumFile.name}`;
         } else {
-            const data: ISimulariumFile = simulariumFile.data;
+            const localFile = simulariumFile as LocalSimFile; // isNetworkedFile checks for this
+            const data: ISimulariumFile = localFile.data;
             const blob = data.getAsBlob();
             return URL.createObjectURL(blob);
         }

--- a/src/components/ShareTrajectoryButton/index.tsx
+++ b/src/components/ShareTrajectoryButton/index.tsx
@@ -2,15 +2,12 @@ import React from "react";
 import { Button, Tooltip } from "antd";
 
 import { TOOLTIP_COLOR } from "../../constants";
-import {
-    NetworkedSimFile,
-    LocalSimFile,
-    isLocalFileInterface,
-} from "../../state/trajectory/types";
+import { NetworkedSimFile, LocalSimFile } from "../../state/trajectory/types";
 import { Share } from "../Icons";
 import ShareTrajectoryModal from "../ShareTrajectoryModal";
 
 import styles from "./style.css";
+import { isOnlineTrajectory } from "../../util/userUrlHandling";
 
 interface ShareTrajectoryButtonProps {
     simulariumFile: LocalSimFile | NetworkedSimFile;
@@ -21,7 +18,7 @@ const ShareTrajectoryButton = ({
 }: ShareTrajectoryButtonProps): JSX.Element => {
     const [isSharing, setIsSharing] = React.useState(false);
 
-    const isLocalFile = isLocalFileInterface(simulariumFile);
+    const trajectoryIsSharable = isOnlineTrajectory(location.href);
 
     const handleShare = () => {
         setIsSharing(!isSharing);
@@ -42,7 +39,7 @@ const ShareTrajectoryButton = ({
                 {isSharing ? (
                     <div className={styles.overlay}>
                         <ShareTrajectoryModal
-                            isLocalFile={isLocalFile}
+                            trajectoryIsSharable={trajectoryIsSharable}
                             closeModal={handleShare}
                         />
                     </div>

--- a/src/components/ShareTrajectoryModal/index.tsx
+++ b/src/components/ShareTrajectoryModal/index.tsx
@@ -17,14 +17,14 @@ import styles from "./style.css";
 import theme from "../theme/light-theme.css";
 
 interface ShareTrajectoryModalProps {
-    isLocalFile: boolean;
+    trajectoryIsSharable: boolean;
     closeModal: () => void;
     timeUnits: TimeUnits;
     displayTimes: DisplayTimes;
 }
 
 const ShareTrajectoryModal = ({
-    isLocalFile,
+    trajectoryIsSharable,
     closeModal,
     timeUnits,
     displayTimes,
@@ -102,7 +102,7 @@ const ShareTrajectoryModal = ({
     };
 
     const modalOptions = {
-        localFile: {
+        errorMessage: {
             content: (
                 <>
                     <h4>{Warn} The current file is stored on your device.</h4>
@@ -134,7 +134,7 @@ const ShareTrajectoryModal = ({
                 </Button>
             ),
         },
-        networkedFile: {
+        isSharable: {
             content: (
                 <>
                     <div>
@@ -177,20 +177,20 @@ const ShareTrajectoryModal = ({
         <CustomModal
             className={classNames(styles.uploadModal, theme.lightTheme)}
             title="Share Trajectory"
-            width={isLocalFile ? 611 : 550}
+            width={trajectoryIsSharable ? 550 : 611}
             onCancel={closeModal}
             mask={false}
             centered
             open
             footer={
-                isLocalFile
-                    ? modalOptions.localFile.footer
-                    : modalOptions.networkedFile.footer
+                trajectoryIsSharable
+                    ? modalOptions.isSharable.footer
+                    : modalOptions.errorMessage.footer
             }
         >
-            {isLocalFile
-                ? modalOptions.localFile.content
-                : modalOptions.networkedFile.content}
+            {trajectoryIsSharable
+                ? modalOptions.isSharable.content
+                : modalOptions.errorMessage.content}
             <Divider />
         </CustomModal>
     );

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -7,6 +7,7 @@ import { VIEWER_PATHNAME } from "../../routes";
 import TRAJECTORIES from "../../constants/networked-trajectories";
 
 import styles from "./style.css";
+import { URL_PARAM_KEY_FILE_NAME } from "../../constants";
 
 interface ViewerTitleProps {
     simulariumFileName: string;
@@ -27,7 +28,10 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
     // networked-trajectories.ts to get its version info
     // TODO: Eventually we should put all the contents of networked-trajectories.ts in the
     // Simularium files themselves
-    const trajectoryId = location.search.replace("?trajFileName=", "");
+    const trajectoryId = location.search.replace(
+        `?${URL_PARAM_KEY_FILE_NAME}=`,
+        ""
+    );
     const currentTrajectory = TRAJECTORIES.find(
         (trajectory) => trajectory.id === trajectoryId
     );

--- a/src/containers/AppHeader/index.tsx
+++ b/src/containers/AppHeader/index.tsx
@@ -31,6 +31,7 @@ import DownloadTrajectoryMenu from "../../components/DownloadTrajectoryMenu";
 interface AppHeaderProps {
     simulariumFile: LocalSimFile | NetworkedSimFile;
     isBuffering: boolean;
+    isNetworkedFile: boolean;
     clearSimulariumFile: ActionCreator<ClearSimFileDataAction>;
     changeToLocalSimulariumFile: ActionCreator<RequestLocalFileAction>;
     changeToNetworkedFile: ActionCreator<RequestNetworkFileAction>;
@@ -48,6 +49,7 @@ class AppHeader extends React.Component<AppHeaderProps> {
             setViewerStatus,
             clearSimulariumFile,
             setError,
+            isNetworkedFile,
         } = this.props;
         let lastModified = 0;
         let displayName = "";
@@ -89,6 +91,7 @@ class AppHeader extends React.Component<AppHeaderProps> {
                     <DownloadTrajectoryMenu
                         isBuffering={isBuffering}
                         simulariumFile={simulariumFile}
+                        isNetworkedFile={isNetworkedFile}
                     />
                 </div>
             </div>
@@ -101,6 +104,8 @@ function mapStateToProps(state: State) {
         simulariumFile:
             trajectoryStateBranch.selectors.getSimulariumFile(state),
         isBuffering: viewerStateBranch.selectors.getIsBuffering(state),
+        isNetworkedFile:
+            trajectoryStateBranch.selectors.getIsNetworkedFile(state),
     };
 }
 

--- a/src/state/trajectory/types.ts
+++ b/src/state/trajectory/types.ts
@@ -60,6 +60,7 @@ export interface NetworkedSimFile {
 }
 export const isLocalFileInterface = (file: any): file is LocalSimFile =>
     !!file.lastModified;
+
 export const isNetworkSimFileInterface = (
     file: any
 ): file is NetworkedSimFile => !!file.title;

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
-import { USER_TRAJ_REDIRECTS } from "../../constants";
+import {
+    URL_PARAM_KEY_FILE_NAME,
+    URL_PARAM_KEY_USER_URL,
+    USER_TRAJ_REDIRECTS,
+} from "../../constants";
 import {
     bindAll,
     convertToSentenceCase,
@@ -16,8 +20,10 @@ import {
     getRedirectUrl,
     getUserTrajectoryUrl,
     isGoogleDriveUrl,
+    isOnlineTrajectory,
     urlCheck,
 } from "../userUrlHandling";
+import { FILE } from "dns";
 
 process.env.GOOGLE_API_KEY = "key";
 describe("General utilities", () => {
@@ -371,6 +377,23 @@ describe("User Url handling", () => {
             const id = "id";
             const result = getUserTrajectoryUrl("dropbox.com/path", id);
             expect(result).toEqual("dl.dropboxusercontent.com/path");
+        });
+    });
+    describe("isOnlineTrajectory", () => {
+        it("it returns true if the trajectory is hosted online", () => {
+            const cloudTrajectoryUrl = `simularium?${URL_PARAM_KEY_USER_URL}=url`;
+            const result = isOnlineTrajectory(cloudTrajectoryUrl);
+            expect(result).toBeTruthy;
+        });
+        it("true if the trajectory is one of our networked models", () => {
+            const networkedUrl = `simularium?${URL_PARAM_KEY_FILE_NAME}=url`;
+            const result = isOnlineTrajectory(networkedUrl);
+            expect(result).toBeTruthy;
+        });
+        it("it returns false if no relevant url params are present", () => {
+            const url = `simularium?other_url_param=value`;
+            const result = isOnlineTrajectory(url);
+            expect(result).toBeFalsy;
         });
     });
 });

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -23,7 +23,6 @@ import {
     isOnlineTrajectory,
     urlCheck,
 } from "../userUrlHandling";
-import { FILE } from "dns";
 
 process.env.GOOGLE_API_KEY = "key";
 describe("General utilities", () => {

--- a/src/util/userUrlHandling.ts
+++ b/src/util/userUrlHandling.ts
@@ -1,8 +1,13 @@
 import { isString } from "lodash";
 
-import { USER_TRAJ_REDIRECTS } from "../constants";
+import {
+    URL_PARAM_KEY_FILE_NAME,
+    URL_PARAM_KEY_USER_URL,
+    USER_TRAJ_REDIRECTS,
+} from "../constants";
 
-const googleDriveUrlRegEx = /(?:drive.google\.com\/file\/d\/)(.*)(?=\/)|(?:drive.google\.com\/file\/d\/)(.*)/g;
+const googleDriveUrlRegEx =
+    /(?:drive.google\.com\/file\/d\/)(.*)(?=\/)|(?:drive.google\.com\/file\/d\/)(.*)/g;
 const googleDriveUrlExcludingIdRegEx = /(drive.google\.com\/file\/d\/)(?=.*)/g;
 
 export const urlCheck = (urlToCheck: any): string => {
@@ -14,7 +19,8 @@ export const urlCheck = (urlToCheck: any): string => {
      * I had to modify the original to allow s3 buckets which have multiple `.letters-letters.` in them
      * and I made the http(s) required
      */
-    const regEx = /(https?:\/\/)([\w\-]){0,200}(\.[a-zA-Z][^\-])([\/\w]*)*\/?\??([^\n\r]*)?([^\n\r]*)/g;
+    const regEx =
+        /(https?:\/\/)([\w\-]){0,200}(\.[a-zA-Z][^\-])([\/\w]*)*\/?\??([^\n\r]*)?([^\n\r]*)/g;
     if (regEx.test(urlToCheck)) {
         return urlToCheck;
     }
@@ -68,18 +74,14 @@ export const getFileIdFromUrl = (
 export const getRedirectUrl = (url: string, fileName: string | undefined) => {
     if (url && fileName && USER_TRAJ_REDIRECTS.includes(url)) {
         // ex) simularium.allencell.org/viewer?trajFileName=endocytosis.simularium
-        return `${location.origin}${
-            location.pathname
-        }?trajFileName=${fileName}`;
+        return `${location.origin}${location.pathname}?trajFileName=${fileName}`;
     } else {
         return "";
     }
 };
 
 export const getGoogleApiUrl = (id: string) => {
-    return `https://www.googleapis.com/drive/v2/files/${id}?alt=media&key=${
-        process.env.GOOGLE_API_KEY
-    }`;
+    return `https://www.googleapis.com/drive/v2/files/${id}?alt=media&key=${process.env.GOOGLE_API_KEY}`;
 };
 
 export const getUserTrajectoryUrl = (url: string, fileId?: string) => {
@@ -88,4 +90,11 @@ export const getUserTrajectoryUrl = (url: string, fileId?: string) => {
     } else {
         return url.replace("dropbox.com", "dl.dropboxusercontent.com");
     }
+};
+
+export const isOnlineTrajectory = (url: string) => {
+    return (
+        url.includes(URL_PARAM_KEY_USER_URL) ||
+        url.includes(URL_PARAM_KEY_FILE_NAME)
+    );
 };

--- a/src/util/userUrlHandling.ts
+++ b/src/util/userUrlHandling.ts
@@ -74,7 +74,7 @@ export const getFileIdFromUrl = (
 export const getRedirectUrl = (url: string, fileName: string | undefined) => {
     if (url && fileName && USER_TRAJ_REDIRECTS.includes(url)) {
         // ex) simularium.allencell.org/viewer?trajFileName=endocytosis.simularium
-        return `${location.origin}${location.pathname}?trajFileName=${fileName}`;
+        return `${location.origin}${location.pathname}?${URL_PARAM_KEY_FILE_NAME}=${fileName}`;
     } else {
         return "";
     }


### PR DESCRIPTION
Problem
=======
Closes #436 

Solution
========
The binary between "networked file" and "local file" is not exactly what we needed for if a file is sharable. "networked" means it is hosted on our server, "local" means it's been loaded into local memory. When you load a file that is hosted on dropbox or other cloud storage, it's technically "local" because it's stored in local memory, but it is still shareable. So I made a new utility function that just checks that there is url param for either a networked file or a cloud storage file. 

One additional change: I was checking other places we are differentiating between the two just to make sure there wasn't the same problem elsewhere and I saw that we were using a type guard to check if a file is networked,  but we had a more extensive check as a selector, so I swapped those. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. `npm start`
2. load Simularium file from your computer, hit share, should get can't share message
3. load http://localhost:9001/viewer?trajUrl=https://www.dropbox.com/scl/fi/2srfuliyjnu3sr1tlfgwf/cells_2023-10-04.simularium?rlkey=hg35vs9cwrla19eq2m0al81t4
4. hit share, should be able to share it. 

Screenshots (optional):
-----------------------
<img width="1421" alt="Screenshot 2023-10-05 at 11 53 54 AM" src="https://github.com/simularium/simularium-website/assets/5170636/cd3a7f8f-bc9c-4b7d-b771-5c6bc1f10bfa">

