### PR TITLE
fix menus offsets

### DIFF
--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -83,19 +83,19 @@ const HelpMenu = (): JSX.Element => {
                         </a>
                     ),
                 },
-                {
-                    key: "version",
-                    label: (
-                        <a
-                            onClick={() => {
-                                setModalVisible(!modalVisible);
-                            }}
-                        >
-                            Version inf
-                        </a>
-                    ),
-                },
             ],
+        },
+        {
+            key: "version",
+            label: (
+                <a
+                    onClick={() => {
+                        setModalVisible(!modalVisible);
+                    }}
+                >
+                    Version info
+                </a>
+            ),
         },
     ];
 

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useLocation, Link } from "react-router-dom";
-import { Menu, Dropdown, Button } from "antd";
+import { Dropdown, Button, MenuProps } from "antd";
 
 import { TUTORIAL_PATHNAME } from "../../routes";
 import { DownArrow } from "../Icons";
@@ -27,49 +27,64 @@ const HelpMenu = (): JSX.Element => {
         ) : (
             <Link to={TUTORIAL_PATHNAME}>Quick start</Link>
         );
-    const menu = (
-        <Menu theme="dark" className={styles.menu}>
-            <Menu.Item key="tutorial">{tutorialLink}</Menu.Item>
-            <Menu.Item key="forum">
+
+    const items: MenuProps["items"] = [
+        {
+            key: "tutorial",
+            label: tutorialLink,
+        },
+        {
+            key: "forum",
+            label: (
                 <a href={FORUM_URL} target="_blank" rel="noopener noreferrer">
                     Forum
                 </a>
-            </Menu.Item>
-            <Menu.Item key="github">
+            ),
+        },
+        {
+            key: "github",
+            label: (
                 <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
                     GitHub
                 </a>
-            </Menu.Item>
-            <Menu.SubMenu
-                title="Submit issue"
-                popupClassName={styles.submenu}
-                popupOffset={[-0.45, -4]}
-                key="submit-issue"
-            >
-                <Menu.Item key="submit-issue-github">
-                    <a
-                        href={ISSUE_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        via GitHub (preferred)
-                    </a>
-                </Menu.Item>
-                <Menu.Item key="web-form">
-                    <a
-                        href={FORUM_BUG_REPORT_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        via Forum (for non-GitHub users)
-                    </a>
-                </Menu.Item>
-            </Menu.SubMenu>
-        </Menu>
-    );
+            ),
+        },
+        {
+            key: "submit-issue",
+            label: "Submit issue",
+            popupClassName: styles.submenu,
+            popupOffset: [-0.45, -4],
+            children: [
+                {
+                    key: "via-github",
+                    label: (
+                        <a
+                            href={ISSUE_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            via GitHub (preferred)
+                        </a>
+                    ),
+                },
+                {
+                    key: "via-forum",
+                    label: (
+                        <a
+                            href={FORUM_BUG_REPORT_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            via Forum (for non-GitHub users)
+                        </a>
+                    ),
+                },
+            ],
+        },
+    ];
 
     return (
-        <Dropdown overlay={menu} placement="bottomRight">
+        <Dropdown menu={{ items, theme: "dark", className: styles.menu }}>
             <Button onClick={(e) => e.preventDefault()} type="ghost">
                 Help {DownArrow}
             </Button>

--- a/src/components/HelpMenu/style.css
+++ b/src/components/HelpMenu/style.css
@@ -11,6 +11,4 @@
     box-shadow: 0 1px 3px black;
     padding: 0;
     width: fit-content;
-    right: 160px !important;
-    left: auto !important;
 }

--- a/src/components/LoadFileMenu/style.css
+++ b/src/components/LoadFileMenu/style.css
@@ -28,6 +28,4 @@
     box-shadow: 0 1px 3px black;
     padding: 0;
     width: fit-content;
-    right: 300px !important;
-    left: auto !important;
 }


### PR DESCRIPTION
Problem
=======
This closes #438 and it might fix #435 

Solution
========
There was some styling that was overriding the default antd submenu. I fixed it, and also updated the help dropdown which was using old components. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. `npm start`
2. drop downs work

Screenshots (optional):
-----------------------
<img width="861" alt="Screenshot 2023-10-09 at 3 34 13 PM" src="https://github.com/simularium/simularium-website/assets/5170636/5bf4a2ff-5927-4b1f-8146-c738f1fcda33">
<img width="650" alt="Screenshot 2023-10-09 at 3 34 18 PM" src="https://github.com/simularium/simularium-website/assets/5170636/5e5bbde7-019a-464b-bc08-0e59178196aa">

