### PR TITLE
check if it's a dependabot PR

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     coverage:
         runs-on: macos-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        if: ${{ github.actor != 'dependabot' }}
         steps:
             - uses: actions/checkout@v3
             - uses: ArtiomTr/jest-coverage-report-action@v2.2.4


### PR DESCRIPTION
Problem
=======
The coverage action fails anytime we have a dependabot PR. 

Solution
========
I changed the conditional in our coverage action to check if the actor is dependabot. The previous conditional wasn't something we were using.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

