### PR TITLE
open aics homepage in new tab

### DIFF
--- a/src/containers/AppHeader/index.tsx
+++ b/src/containers/AppHeader/index.tsx
@@ -63,7 +63,12 @@ class AppHeader extends React.Component<AppHeaderProps> {
         return (
             <div className={styles.pageHeader}>
                 <div className={styles.leftLinks}>
-                    <a href="https://allencell.org" title="Allen Cell Explorer">
+                    <a
+                        href="https://allencell.org"
+                        title="Allen Cell Explorer"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         {AicsLogo}
                     </a>
                     <span className={styles.verticalBar}>|</span>


### PR DESCRIPTION
Problem:
During a different review @lynwilhelm requested that the AICS homepage should open in a new tab, current behavior was to navigate in the current tab.

To verify:
From any simularium window, clicking on this:
<img width="165" alt="Screenshot 2023-12-13 at 2 33 50 PM" src="https://github.com/simularium/simularium-website/assets/24981838/a98b5314-ac1c-4fa1-aa0c-37a3dcfdd1e3">
should open a new tab.
