### PR TITLE
fix: organize colors, modal buttons

### DIFF
--- a/src/components/CustomModal/index.tsx
+++ b/src/components/CustomModal/index.tsx
@@ -2,11 +2,15 @@ import React from "react";
 import { Modal, ModalProps } from "antd";
 import classNames from "classnames";
 
+import theme from "../theme/light-theme.css";
 import styles from "./style.css";
 
 /** Tiny wrapper component to keep modal styling consistent */
 const CustomModal: React.FC<ModalProps> = (props) => (
-    <Modal {...props} className={classNames(styles.modal, props.className)} />
+    <Modal
+        {...props}
+        className={classNames(theme.lightTheme, styles.modal, props.className)}
+    />
 );
 
 export default CustomModal;

--- a/src/components/CustomModal/style.css
+++ b/src/components/CustomModal/style.css
@@ -33,6 +33,7 @@
     height: 40px;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .modal :global(.ant-checkbox-inner) {

--- a/src/components/CustomModal/style.css
+++ b/src/components/CustomModal/style.css
@@ -12,7 +12,7 @@
 
 .modal :global(.ant-modal-footer) {
     padding: 12px 16px 20px;
-    background-color: var(--modal-content-bg);
+    background-color: var(--light-theme-modal-content-bg);
     max-height: 56px;
 }
 
@@ -54,4 +54,8 @@
 
 .modal :global(.ant-modal-close):hover{
     color: var(--white-three);
+}
+
+.modal :global(.ant-modal-footer) button {
+    width: 82px;
 }

--- a/src/components/FileUploadModal/index.tsx
+++ b/src/components/FileUploadModal/index.tsx
@@ -18,7 +18,6 @@ import LocalFileUpload from "../LocalFileUpload";
 import uploadFiles from "./upload-local-files";
 
 import styles from "./style.css";
-import theme from "../theme/light-theme.css";
 
 const enum UploadTab {
     // this version of antd requires tab keys to be strings

--- a/src/components/FileUploadModal/index.tsx
+++ b/src/components/FileUploadModal/index.tsx
@@ -102,7 +102,6 @@ const FileUploadModal: React.FC<FileUploadModalProps> = ({
                 Cancel
             </Button>
             <Button
-                type="primary"
                 className="primary-button"
                 disabled={disableLoad}
                 onClick={onLoadClick}
@@ -114,7 +113,7 @@ const FileUploadModal: React.FC<FileUploadModalProps> = ({
 
     return (
         <CustomModal
-            className={[styles.uploadModal, theme.lightTheme].join(" ")}
+            className={styles.uploadModal}
             title="Choose a Simularium file to load"
             open
             footer={footerButtons}

--- a/src/components/LandingPage/style.css
+++ b/src/components/LandingPage/style.css
@@ -140,29 +140,3 @@
 .markdown p {
     margin-bottom: 2em;
 }
-
-/* These will be useful if we ever bring a call-to-action button back */
-/* .call-to-action-panel :global(.ant-btn) {
-    display: block;
-    width: 130px;
-    height: 30px;
-    font-size: 14px;
-    margin-top: 3em;
-    margin-bottom: 0.5em;
-    margin-left: auto;
-    margin-right: auto;
-    transition: 0.3s;
-    border-radius: 3px;
-}
-
-.call-to-action-panel :global(.ant-btn-primary),
-.call-to-action-panel :global(.ant-btn-ghost:hover) {
-    background-color: var(--light-theme-button-purple);
-    color: var(--light-theme-background-purple);
-}
-
-.call-to-action-panel :global(.ant-btn-ghost),
-:global(.ant-btn-primary:hover) {
-    background-color: transparent;
-    color: var(--light-theme-button-purple);
-} */

--- a/src/components/LocalFileUpload/index.tsx
+++ b/src/components/LocalFileUpload/index.tsx
@@ -70,7 +70,12 @@ const LocalFileUpload: React.FC<FileUploadProps> = ({
                 }}
             >
                 {children || (
-                    <Button className="secondary-button">Select file</Button>
+                    <Button
+                        className="secondary-button"
+                        ant-click-animating-without-extra-node={false}
+                    >
+                        Select file
+                    </Button>
                 )}
             </Link>
         </Upload>

--- a/src/components/LocalFileUpload/index.tsx
+++ b/src/components/LocalFileUpload/index.tsx
@@ -70,12 +70,7 @@ const LocalFileUpload: React.FC<FileUploadProps> = ({
                 }}
             >
                 {children || (
-                    <Button
-                        className="secondary-button"
-                        ant-click-animating-without-extra-node={false}
-                    >
-                        Select file
-                    </Button>
+                    <Button className="secondary-button">Select file</Button>
                 )}
             </Link>
         </Upload>

--- a/src/components/LocalFileUpload/style.css
+++ b/src/components/LocalFileUpload/style.css
@@ -16,7 +16,7 @@
 }
 
 .file-upload :global(.ant-upload-list-item-card-actions-btn) svg {
-    color: #d14040;
+    color: var(--cancel-icon-color);
 }
 
 .file-upload :global(.ant-upload-list-text .ant-upload-list-item-name) {

--- a/src/components/ShareTrajectoryModal/index.tsx
+++ b/src/components/ShareTrajectoryModal/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import classNames from "classnames";
 import { connect } from "react-redux";
 import { Button, Checkbox, Divider, Input } from "antd";
 

--- a/src/components/ShareTrajectoryModal/index.tsx
+++ b/src/components/ShareTrajectoryModal/index.tsx
@@ -14,7 +14,6 @@ import { URL_PARAM_KEY_TIME } from "../../constants";
 import { editUrlParams } from "../../util";
 
 import styles from "./style.css";
-import theme from "../theme/light-theme.css";
 
 interface ShareTrajectoryModalProps {
     trajectoryIsSharable: boolean;
@@ -125,11 +124,7 @@ const ShareTrajectoryModal = ({
                 </>
             ),
             footer: (
-                <Button
-                    className={styles.okButton}
-                    type="default"
-                    onClick={closeModal}
-                >
+                <Button className={"secondary-button"} onClick={closeModal}>
                     Ok
                 </Button>
             ),
@@ -143,12 +138,14 @@ const ShareTrajectoryModal = ({
                             value={url}
                             disabled
                         />
-                        <Button type="text" onClick={copyToClipboard}>
+                        <Button
+                            className={"primary-button"}
+                            onClick={copyToClipboard}
+                        >
                             Copy {Link}
                         </Button>
                     </div>
                     <div className={styles.timeInputContainer}>
-                        {" "}
                         <Checkbox onChange={handleAllowUserInput}></Checkbox>
                         <p className={styles.timeInputText}>Start at</p>
                         <Input
@@ -158,9 +155,8 @@ const ShareTrajectoryModal = ({
                             onChange={handleUserInput}
                         />
                         <div>
-                            {" "}
-                            /{displayTimes.roundedLastFrameTime}{" "}
-                            {timeUnits ? timeUnits.name : null}{" "}
+                            /{displayTimes.roundedLastFrameTime}
+                            {timeUnits ? timeUnits.name : null}
                         </div>
                     </div>
                 </>
@@ -175,7 +171,7 @@ const ShareTrajectoryModal = ({
 
     return (
         <CustomModal
-            className={classNames(styles.uploadModal, theme.lightTheme)}
+            className={styles.uploadModal}
             title="Share Trajectory"
             width={trajectoryIsSharable ? 550 : 611}
             onCancel={closeModal}

--- a/src/components/ShareTrajectoryModal/style.css
+++ b/src/components/ShareTrajectoryModal/style.css
@@ -1,7 +1,3 @@
-.ok-button {
-    width: 75px;
-}
-
 .body-text {
     padding-bottom: 10px;
 }
@@ -21,7 +17,7 @@
 
 .time-input[disabled] {
     background: transparent;
-    color: var(--medium-grey);
+    color: var(--light-theme-input-disabled-colo);
 }
 
 .time-input-text {

--- a/src/components/ShareTrajectoryModal/style.css
+++ b/src/components/ShareTrajectoryModal/style.css
@@ -17,7 +17,7 @@
 
 .time-input[disabled] {
     background: transparent;
-    color: var(--light-theme-input-disabled-colo);
+    color: var(--light-theme-input-disabled-color);
 }
 
 .time-input-text {

--- a/src/components/StarCheckbox/style.css
+++ b/src/components/StarCheckbox/style.css
@@ -3,7 +3,7 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0;
-    color: #4a4a4a;
+    color: var(--star-checkbox-bg);
     font-size: 14px;
     font-variant: tabular-nums;
     line-height: 1.5715;
@@ -18,7 +18,7 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0;
-    color: #4a4a4a;
+    color: var(--star-checkbox-bg);
     font-size: 14px;
     font-variant: tabular-nums;
     line-height: 1.5715;

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -15,7 +15,7 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
     };
 
     const footerButton = (
-        <Button type="primary" onClick={closeModal}>
+        <Button className={"secondary-button"} onClick={closeModal}>
             Close
         </Button>
     );
@@ -31,19 +31,15 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
             width={425}
         >
             <div>
-                {" "}
-                Application:{" "}
+                Application:
                 <span className={styles.blueText}>
-                    {" "}
-                    simularium-website v{SIMULARIUM_WEBSITE_VERSION}{" "}
+                    simularium-website v{SIMULARIUM_WEBSITE_VERSION}
                 </span>
             </div>
             <div>
-                {" "}
-                Viewer:{" "}
+                Viewer:
                 <span className={styles.blueText}>
-                    {" "}
-                    simularium-viewer v{SIMULARIUM_VIEWER_VERSION}{" "}
+                    simularium-viewer v{SIMULARIUM_VIEWER_VERSION}
                 </span>
             </div>
         </CustomModal>

--- a/src/components/VersionModal/index.tsx
+++ b/src/components/VersionModal/index.tsx
@@ -31,13 +31,13 @@ const VersionModal: React.FC<VersionModalProps> = ({ setModalVisible }) => {
             width={425}
         >
             <div>
-                Application:
+                Application:{" "}
                 <span className={styles.blueText}>
                     simularium-website v{SIMULARIUM_WEBSITE_VERSION}
                 </span>
             </div>
             <div>
-                Viewer:
+                Viewer:{" "}
                 <span className={styles.blueText}>
                     simularium-viewer v{SIMULARIUM_VIEWER_VERSION}
                 </span>

--- a/src/components/VersionModal/style.css
+++ b/src/components/VersionModal/style.css
@@ -14,5 +14,5 @@
 }
 
 .container :global(.ant-modal-footer) {
-    background-color: var(--modal-content-bg);
+    background-color: var(--light-theme-modal-content-bg);
 }

--- a/src/components/theme/light-theme.css
+++ b/src/components/theme/light-theme.css
@@ -2,7 +2,7 @@
 
 /* primary buttons */
 .light-theme :global(.primary-button),
-.light-theme :global(.secondary-button):focus {
+.light-theme :global(.primary-button):focus {
     background-color: var(--light-theme-btn-primary-bg);
     border: var(--light-theme-btn-primary-border);
     color: var(--light-theme-btn-primary-color);

--- a/src/components/theme/light-theme.css
+++ b/src/components/theme/light-theme.css
@@ -1,42 +1,41 @@
-/* Default and primary button colors differ within modals */
+/* Primary and secondary button colors differ within modals */
 
-/* primary button */
+/* primary buttons */
 .light-theme :global(.primary-button),
-.light-theme :global(.primary-button):focus {
-    border: 1px solid var(--light-theme-button-primary-bg);
-    border-radius: 3px;
-    background-color: var(--light-theme-button-primary-bg);
-    color: var(--light-theme-button-primary-text);
+.light-theme :global(.secondary-button):focus {
+    background-color: var(--light-theme-btn-primary-bg);
+    border: var(--light-theme-btn-primary-border);
+    color: var(--light-theme-btn-primary-color);
 }
 
-.light-theme :global(.primary-button):hover {
-    color: var(--light-theme-button-primary-text-hover);
-    border: 1px solid var(--light-theme-button-primary-border-hover);
+.light-theme :global(.primary-button:hover) {
+    background-color: var(--light-theme-btn-primary-hover-bg);
+    border: var(--light-theme-btn-primary-hover-border);
+    color: var(--light-theme-btn-primary-hover-color);
 }
 
-.light-theme :global(.primary-button):disabled {
-    border: 1px solid var(--light-theme-button-primary-text-disabled);
-    color: var(--light-theme-button-primary-text-disabled);
-    background-color: var(--light-theme-button-primary-bg-disabled);
+.light-theme :global(.primary-button[disabled]) {
+    background: var(--light-theme-btn-primary-disabled-bg);
+    border: var(--light-theme-btn-primary-disabled-border);
+    color: var(--light-theme-btn-primary-disabled-color);
 }
 
-/* secondary button */
+/* secondary buttons: typically: close, ok, cancel */
 .light-theme :global(.secondary-button),
 .light-theme :global(.secondary-button):focus {
-    border: 1px solid var(--light-theme-button-secondary-border);
-    border-radius: 3px;
-    background-color: transparent;
-    color: var(--light-theme-button-secondary-text);
+    background-color: var(--light-theme-btn-secondary-bg);
+    border-color: var(--light-theme-btn-secondary-border);
+    color: var(--light-theme-btn-secondary-color);
 }
 
-.light-theme :global(.secondary-button):hover {
-    background-color: var(--light-theme-button-secondary-bg-hover);
-    color: var(--light-theme-button-secondary-text-hover);
-    border: 1px solid var(--light-theme-button-secondary-border);
+.light-theme :global(.secondary-button:hover) {
+    background-color: var(--light-theme-btn-secondary-hover-bg);
+    border-color: var(--light-theme-btn-secondary-hover-border);
+    color: var(--light-theme-btn-secondary-hover-color);
 }
 
-.light-theme :global(.secondary-button):disabled {
-    border: 1px solid var(--light-theme-button-primary-border-disabled);
-    color: var(--light-theme-button-secondary-text-disabled);
-    background-color: transparent;
+.light-theme :global(.secondary-button[disabled]) {
+    background: var(--light-theme-btn-secondary-disabled-bg);
+    border: var(--light-theme-btn-secondary-disabled-border);
+    color: var(--light-theme-btn-secondary-disabled-color);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -80,7 +80,7 @@ use the :after pseduo selector to input the content.
 */
 .icon-focus:before {
     content: "\e90a";
-    color: #d8d8d8;
+    color: var(--icon-moon-color);
 }
 
 .icon-rotate:before {

--- a/src/styles/ant-vars.less
+++ b/src/styles/ant-vars.less
@@ -9,12 +9,12 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 @baby-purple: #b59ff6;
 @dark-purple: #3b3649;
 @allen-purple: #8d87aa;
-@greyish-brown: #4a4a4a;
+@grayish-brown: #4a4a4a;
 @highlight-green: #b2d030;
 @blue: #0094FF;
 @medium-dark-gray: #8b8b8b;
-@pale-grey: #ddd9ec;
-@warm-grey: #979797;
+@pale-gray: #ddd9ec;
+@warm-gray: #979797;
 @heather: #bab5c9;
 
 // -------- Colors -----------
@@ -46,11 +46,11 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 @font-family: 'Overpass', sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
   'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
   'Noto Color Emoji';
-@text-color             : @greyish-brown;
+@text-color             : @grayish-brown;
 //@text-color-secondary   : darken(#fff, 40%);
 
 @background-color-light : lighten(@dark-three, 10%);  // background of header and selected item
-//@background-color-base  : hsv(0, 0, 96%);  // Default grey background color
+//@background-color-base  : hsv(0, 0, 96%);  // Default gray background color
 
 // The background colors for active and hover states for things like
 // list items or table cells.
@@ -143,7 +143,7 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 // Radio buttons
 @radio-button-bg: @black;
 @radio-button-checked-bg: @dark-three;
-@radio-button-color: @greyish-brown;
+@radio-button-color: @grayish-brown;
 @radio-button-hover-color: @primary-5;
 @radio-button-active-color: @dark-three;
 @radio-disabled-button-checked-bg: tint(@black, 90%);
@@ -201,7 +201,7 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 // @modal-header-close-size: 56px;
 @modal-content-bg: #e7e4f2;
 @modal-heading-color: #fff;
-@modal-close-color: @warm-grey;
+@modal-close-color: @warm-gray;
 @modal-footer-bg: #f6f4ff;
 @modal-footer-border-color-split: @heather;
 @modal-footer-border-width: 1px;

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -13,30 +13,39 @@
     --white-six: #e7e7e7;
     --transparent-white: rgba(255, 255, 255, 0.65);
     --dim-gray: #383838;
-    --dim-gray-two: #6E6E6E;
-    --purplish-gray: #4A4658;
-    --pale-grey: #ddd9ec;
+    --dim-gray-two: #6e6e6e;
+    --purplish-gray: #4a4658;
+    --pale-gray: #ddd9ec;
     --heather: #bab5c9;
     --text-gray: #a0a0a0;
     --grayish-brown: #4a4a4a;
     --warm-gray: #979797;
-    --charcoal-grey: #3b3649;
-    --dark-blue-grey: #2d224d;
-    --background-dark-gray: #131313;
+    --charcoal-gray: #3b3649;
+    --light-purple: #e7e4f2;
     --baby-purple: #b59ff6;
     --allen-purple: #8d87aa;
-    --blue: #0094FF;
-    --modal-content-bg: #e7e4f2;
-    --baby-purple-two: #DCCFFF;
-    --medium-grey: #AEAEAE;
-    --dark-blue-gray: #69738A;
-    --background-dim-gray: var(--dim-gray);
-    --border-gray: var(--white-six);
+    --blue: #0094ff;
+    --baby-purple-two: #dccfff;
+    --medium-gray: #aeaeae;
+    --dark-blue-gray: #69738a;
+    --brick-red: #d14040;
+    /* Non-theme variables */
+    --icon-moon-color: var(--white-three);
+    --star-checkbox-bg: var(--grayish-brown);
     --footer-bg: var(--dark-three);
     --footer-text: var(--warm-gray);
-    --footer-text-border-bottom: var(--greyish-brown);
+    --footer-text-border-bottom: var(--grayish-brown);
     --footer-link: var(--blue);
     --input-border-highlight: var(--heather);
+    --color-picker-tooltip: var(--dark-blue-gray);
+    --viewer-btn-bg-default: var(--dark-three);
+    --viewer-btn-bg-hover: var(--purplish-gray);
+    --viewer-btn-bg-disabled: var(--dark-three);
+    --viewer-btn-border-active: var(--white-three);
+    --viewer-btn-color-default: var(--white-three);
+    --viewer-btn-color-disabled: var(--grayish-brown);
+    --cancel-icon-color: var(--brick-red);
+    /* Dark theme */
     --dark-theme-primary-color: var(--baby-purple);
     --dark-theme-body-bg: var(--black);
     --dark-theme-header-bg: var(--dark-three);
@@ -56,50 +65,40 @@
     --dark-theme-btn-bg: var(--dark-three);
     --dark-theme-btn-color: var(--white-three);
     --dark-theme-btn-color-dim: var(--text-gray);
-    --dark-theme-btn-hover-bg: var(--greyish-brown);
-    --dark-theme-btn-disabled-bg: var(--dark-two);
-    --dark-theme-btn-disabled-color: rgb(231 231 231 / 32%);
+    --dark-theme-btn-hover-bg: var(--grayish-brown);
     --dark-theme-btn-primary: var(--baby-purple);
-    --dark-theme-btn-primary-text: var(--dark-two);
-    --dark-theme-slider-color: var(--white-three);    
-    --dark-theme-tooltip-bg: var(--charcoal-grey);
+    --dark-theme-tooltip-bg: var(--charcoal-gray);
     --dark-theme-version-badge-purple: var(--dark-five);
-    --light-theme-background-purple: var(--pale-grey);
-    --light-theme-button-purple: var(--dark-blue-grey);
-
-    --light-theme-button-primary-text: var(--white-three);
-    --light-theme-button-primary-bg: var(--dark-blue-grey);
-    --light-theme-button-primary-text-hover: var(--baby-purple);
-    --light-theme-button-primary-border-hover: var(--dark-four);
-    --light-theme-button-primary-text-disabled: var(--white-three);
-    --light-theme-button-primary-bg-disabled: var(--heather);
-
-
-    --light-theme-button-secondary-text: var(--dark-four);
-    --light-theme-button-secondary-border: var(--dark-four);
-    --light-theme-button-secondary-text-hover: var(--baby-purple);
-    --light-theme-button-secondary-bg-hover: var(--charcoal-grey);
-    --light-theme-button-secondary-text-disabled: var(--heather);
-    --light-theme-button-primary-border-disabled: var(--heather);
-
-
+    /* Light theme */
+    --light-theme-background-purple: var(--pale-gray);
     --light-theme-heading1-gray: var(--dark-three);
-    --light-theme-heading2-gray: var(--greyish-brown);
+    --light-theme-heading2-gray: var(--grayish-brown);
     --light-theme-panel-light-gray: var(--white-four);
-    --light-theme-button-light-gray: var(--white-four);
     --light-theme-card-bg-white: var(--pure-white);
     --light-theme-version-badge-purple: var(--allen-purple);
     --light-theme-background-off-white: var(--off-white);
     --light-theme-faint-text: var(--white-two);
-    --light-theme-modal-supplemental-text: var(--charcoal-grey);
-    --light-theme-modal-btn-default-color: var(--dark-four);
-    --light-theme-btn-default-disabled-bg: var(--heather);
-    --color-picker-tooltip: var(--dark-blue-gray);
-    --viewer-btn-bg-default: var(--dark-three);
-    --viewer-btn-bg-hover: var(--purplish-gray);
-    --viewer-btn-bg-disabled: var(--dark-three);
-    --viewer-btn-border-active: var( --white-three);
-    --viewer-btn-border-on: var(--dim-gray-two);
-    --viewer-btn-color-default: var(--white-three);
-    --viewer-btn-color-disabled: var(--grayish-brown);
+    --light-theme-modal-content-bg: var(--light-purple);
+    --light-theme-modal-supplemental-text: var(--charcoal-gray);
+    --light-theme-modal-supplemental-text: var(--charcoal-gray);
+    /* primary modal buttons */
+    --light-theme-btn-primary-bg: var(--dark-four);
+    --light-theme-btn-primary-border: var(--dark-four);
+    --light-theme-btn-primary-color: var(--white-three);
+    --light-theme-btn-primary-hover-bg: var(--dark);
+    --light-theme-btn-primary-hover-border: var(--dark);
+    --light-theme-btn-primary-hover-color: var(--baby-purple);
+    --light-theme-btn-primary-disabled-bg: var(--heather);
+    --light-theme-btn-primary-disabled-border: var(--heather);
+    --light-theme-btn-primary-disabled-color: var(--white-three);
+    /* secondary modal buttons */
+    --light-theme-btn-secondary-bg: transparent;
+    --light-theme-btn-secondary-border: var(--dark-four);
+    --light-theme-btn-secondary-color: var(--dark-four);
+    --light-theme-btn-secondary-hover-bg: var(--dark);
+    --light-theme-btn-secondary-hover-border: var(--dark);
+    --light-theme-btn-secondary-hover-color: var(--baby-purple);
+    --light-theme-btn-secondary-disabled-bg: transparent;
+    --light-theme-btn-secondary-disabled-border: var(--heather);
+    --light-theme-btn-secondary-disabled-color: var(--heather);
 }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -78,6 +78,7 @@
     --light-theme-version-badge-purple: var(--allen-purple);
     --light-theme-background-off-white: var(--off-white);
     --light-theme-faint-text: var(--white-two);
+    --light-theme-input-disabled-color: var(--medium-gray);
     --light-theme-modal-content-bg: var(--light-purple);
     --light-theme-modal-supplemental-text: var(--charcoal-gray);
     --light-theme-modal-supplemental-text: var(--charcoal-gray);


### PR DESCRIPTION
### Time to review
_Medium: mostly reorganization, pruning of unused variables, renaming, etc_

Problem
=======
A maintenance PR to organize colors modal button styles, and make some style fixes on modal buttons.
Preliminary work to some updates to `CustomModal`.

With the exception of modal buttons, these changes should _not affect_ current styling anywhere else in the application.

### To review:
Inspect the website for inadvertent changes, and inspect the three modals: share trajectory, version info, upload file (screenshots below).

Almost all changes are trivial except for `colors.css`.
In `colors` I have tried hard to confirm that all removed variables were unused, and no styles were unintentionally changed by reorganization/pruning. Missing something here and messing with other styles unintentionally is the primary concern in review

### Theme and styling:
- apply light theme at the custom-modal level, remove from implementing components
- consistently use `primary-button` and `secondary-button` class names to match theme, remove `antd `button `type` to prevent adding and removing their styling.- use consistent naming scheme for light theme color variables
- removed a large commented styling code block that was "just in case" storage, 3 years old, not current design.
- button fixes, refer to: [figma source of truth](https://www.figma.com/file/u4lZYuVwbsFpzBikgwAVRb/Master-components-Simularium?type=design&node-id=0-1&mode=design&t=7JAVneFGwyFwd5Xd-0): darken hover color on secondary buttons, bring version modal button into scheme, make copy button on share trajectory modal primary, make share trajectory error modal secondary, make all modal footer buttons equal width
- removed border and border radius styles in light theme that seem to be inherited correctly from antd defaults and swapped in new variable names, provide vars for color, bg, and border color across the board for consistency

### General color maintenance:
- looked for anywhere hexes were used directly in stylesheets and made variables
- looked for any variables that were not currently used anywhere, removed them. All removed/renamed variables are listed below for confirmation
- changed all instances of "grey" to "gray" not a huge deal but we did have both `dark-blue-grey` and `dark-blue-gray` defined and it also makes searching the repo more reliable if we are consistent
- make hexes consistently lower case

removed unused css vars:
```
--dark-blue-grey
--viewer-btn-border-on
--border-gray
--background-dim-gray
--background-dark-gray
--light-theme-button-purple
--light-theme-button-light-gray
--light-theme-input-border-highlight
--dark-theme-btn-disabled-color
--dark-theme-btn-primary-text
--dark-theme-btn-disabled-bg
--dark-theme-slider-color
```

renamed/reused:
(using primary and secondary now to match UX usage)
```
--light-theme-btn-default-bg
--light-theme-btn-default-color
--light-theme-btn-default-border
--light-theme-btn-default-hover-bg
--light-theme-btn-default-hover-color
--light-theme-btn-default-hover-border
--light-theme-btn-default-disabled-bg
--light-theme-btn-default-disabled-color
--light-theme-btn-default-disabled-border
```



Screenshots (optional):
-----------------------
Old:
<img width="625" alt="Screenshot 2024-03-06 at 5 11 55 PM" src="https://github.com/simularium/simularium-website/assets/24981838/84557fe5-38d2-4a27-a5d9-d12f1dfc0821">
New:
<img width="623" alt="Screenshot 2024-03-06 at 5 31 55 PM" src="https://github.com/simularium/simularium-website/assets/24981838/0e9127ad-b280-4612-973e-24f6de9a690f">
Old:
<img width="654" alt="Screenshot 2024-03-06 at 5 10 16 PM" src="https://github.com/simularium/simularium-website/assets/24981838/f5cd7f20-ad73-44da-8785-a959095e7608">
New:
<img width="672" alt="Screenshot 2024-03-06 at 5 10 10 PM" src="https://github.com/simularium/simularium-website/assets/24981838/20444c61-2b82-46f6-b3fb-0b7fcdf87f98">



Old:
<img width="471" alt="Screenshot 2024-03-06 at 5 09 38 PM" src="https://github.com/simularium/simularium-website/assets/24981838/c233526e-9786-4d46-82bd-cb892a212d19">
New:
<img width="481" alt="Screenshot 2024-03-06 at 5 25 20 PM" src="https://github.com/simularium/simularium-website/assets/24981838/fffafa5b-55e3-4ab2-8174-1a369458a5c8">
Old:
<img width="568" alt="Screenshot 2024-03-06 at 5 08 11 PM" src="https://github.com/simularium/simularium-website/assets/24981838/edbe6ae0-833f-49db-93c9-dfd208f86c39">
New:
<img width="585" alt="Screenshot 2024-03-06 at 5 07 36 PM" src="https://github.com/simularium/simularium-website/assets/24981838/7cfa1b7d-bade-4713-bb8f-c8f82ab85597">




