### PR TITLE
fix the html loader result

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9323,9 +9323,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -11252,9 +11252,9 @@
             ]
         },
         "node_modules/ignore": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
-            "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -20455,9 +20455,9 @@
             "dev": true
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"

--- a/webpack/index.template.html
+++ b/webpack/index.template.html
@@ -20,26 +20,12 @@
         content="The Simularium Viewer makes it easy to share and interrogate interactive 3D visualizations of biological simulation trajectories and related plots directly in a web browser.">
     
     <!-- Facebook Meta Tags -->
-    <meta property="og:title" content="Simularium" />
-    <meta property="og:url" content="https://simularium.allencell.org/">
+    <!-- the rest of the tags are set by the HtmlWebpackPlugin  -->
     <meta property="og:image" content="../src/assets/meta-tag.png">
-    <meta property="og:description"
-        content="The Simularium Viewer makes it easy to share and interrogate interactive 3D visualizations of biological simulation trajectories and related plots directly in a web browser.">
-    <meta property="og:image:type" content="image/png">
-    <meta property="og:image:width" content="2048">
-    <meta property="og:image:height" content="1115">
-    <meta property="og:image:alt"
-        content="A view of the Simularium viewer showing a 3D scene of molecular interactions, with data plots on the right side of the screen, and a menu of the visible agents on the left side.">
-    <meta property="og:type" content="website">
 
-    
     <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="simularium.allencell.org">
-    <meta property="twitter:url" content="https://simularium.allencell.org/">
-    <meta name="twitter:title" content="Simularium">
-    <meta name="twitter:description"
-        content="The Simularium Viewer makes it easy to share and interrogate interactive 3D visualizations of biological simulation trajectories and related plots directly in a web browser.">
+    <!-- the rest of the tags are set by the HtmlWebpackPlugin  -->
+
     <meta name="twitter:image"
         content="../src/assets/meta-tag.png">
 

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -34,6 +34,7 @@ const getBasePlugins = (dist, env) => {
                 ["og:description"]:
                     "The Simularium Viewer makes it easy to share and interrogate interactive 3D visualizations of biological simulation trajectories and related plots directly in a web browser.",
                 ["og:url"]: "https://simularium.allencell.org",
+                ["og:type"]: "website",
                 ["og:image:type"]: "image/png",
                 ["og:image:width"]: "2048",
                 ["og:image:height"]: "1115",

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -26,6 +26,25 @@ const getBasePlugins = (dist, env) => {
         new HtmlWebpackPlugin({
             favicon: "./src/assets/AICS-logo.svg",
             template: path.resolve(__dirname, "index.template.html"),
+            meta: {
+                viewport: "width=device-width, initial-scale=1",
+                description:
+                    "The Simularium Viewer makes it easy to share and interrogate interactive 3D visualizations of biological simulation trajectories and related plots directly in a web browser.",
+                ["og:title"]: "Simularium",
+                ["og:description"]:
+                    "The Simularium Viewer makes it easy to share and interrogate interactive 3D visualizations of biological simulation trajectories and related plots directly in a web browser.",
+                ["og:url"]: "https://simularium.allencell.org",
+                ["og:image:type"]: "image/png",
+                ["og:image:width"]: "2048",
+                ["og:image:height"]: "1115",
+                ["og:image:alt"]:
+                    "A view of the Simularium viewer showing a 3D scene of molecular interactions, with data plots on the right side of the screen, and a menu of the visible agents on the left side.",
+                ["twitter:card"]: "summary_large_image",
+                ["twitter:title"]: "Simularium",
+                ["twitter:description"]:
+                    "The Simularium Viewer makes it easy to share and interrogate interactive 3D visualizations of biological simulation trajectories and related plots directly in a web browser.",
+                ["twitter:url"]: "https://simularium.allencell.org/",
+            },
         }),
         new webpack.EnvironmentPlugin({
             GH_BUILD: !!process.env.GH_BUILD,

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -134,6 +134,9 @@ module.exports = ({ analyze, env, dest = "dist" } = {}) => ({
             {
                 test: /\.html$/i,
                 loader: "html-loader",
+                options: {
+                        esModule: false,
+                },
             },
             {
                 test: /\.md$/,


### PR DESCRIPTION
Time estimate or Size
=======
small

Problem
=======
the `html-loader` was exporting a module instead of just the png for the og tag image 

Solution
========
I added the `esModules: false`
While I was investigating this, I realized we already had `HtmlWebpackPlugin` which you can use to set metatags that don't need any processing done to them, so I also moved all the tags without paths into there. 

Verify
=======
I deployed it on gh-pages and you can see the preview: https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fsimularium.github.io%2Fsimularium-website

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

I was able to test this by momentarily overwriting a nightly build and the image loaded. 
