### PR TITLE
fix/hide tooltips after click

### DIFF
--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -74,7 +74,7 @@ const Checkbox = (props: CheckboxTypeProps): JSX.Element => {
                 {...childProps}
                 onChange={(e) => {
                     setShowTooltip(false);
-                    childProps.onChange ? childProps.onChange(e) : null;
+                    childProps.onChange?.(e);
                 }}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState } from "react";
 import { Checkbox as AntdCheckbox, Tooltip } from "antd";
 import { CheckboxProps } from "antd/lib/checkbox";
 
@@ -31,6 +31,23 @@ const Checkbox = (props: CheckboxTypeProps): JSX.Element => {
     const childProps = { ...props, checkboxType: null, checkboxLevel: null };
     const checkboxLevel = props.checkboxLevel ? props.checkboxLevel : "default";
 
+    const [showTooltip, setShowTooltip] = useState(false);
+    const [tooltipTitle, setTooltipTitle] = useState("Hide");
+
+    const updateTooltipTitle = () => {
+        const text = !props.checked ? "Show" : "Hide";
+        setTooltipTitle(text);
+    };
+
+    const handleMouseEnter = () => {
+        setShowTooltip(true);
+    };
+
+    const handleMouseLeave = () => {
+        setShowTooltip(false);
+        updateTooltipTitle();
+    };
+
     if (props.checkboxType === CHECKBOX_TYPE_STAR) {
         /* 
         Wrapping the StarCheckbox in a Tooltip component as done below for AntdCheckbox
@@ -44,14 +61,24 @@ const Checkbox = (props: CheckboxTypeProps): JSX.Element => {
     }
     return (
         <Tooltip
-            title={props.checked ? "Hide" : "Show"}
+            title={tooltipTitle}
             placement="top"
             mouseEnterDelay={TOOLTIP_DELAY}
             // Position tooltip with alignConfig object: https://github.com/yiminghe/dom-align#usage
             align={{ offset: tooltipOffsets[checkboxLevel] }}
             color={TOOLTIP_COLOR}
+            open={showTooltip}
+            onOpenChange={updateTooltipTitle}
         >
-            <AntdCheckbox {...childProps} />
+            <AntdCheckbox
+                {...childProps}
+                onChange={(e) => {
+                    setShowTooltip(false);
+                    childProps.onChange ? childProps.onChange(e) : null;
+                }}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            />
         </Tooltip>
     );
 };

--- a/src/components/StarCheckbox/index.tsx
+++ b/src/components/StarCheckbox/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import classNames from "classnames";
 import { Tooltip } from "antd";
 import { CheckboxChangeEvent, CheckboxProps } from "antd/lib/checkbox";
@@ -14,6 +14,9 @@ const StarCheckbox = ({
     value,
     className,
 }: CheckboxProps): JSX.Element => {
+    const [showTooltip, setShowTooltip] = useState(false);
+    const [tooltipTitle, setTooltipTitle] = useState("Highlight");
+
     const parentClassnames = className ? className.split(" ") : [];
     const wrapperClassnames = classNames([...parentClassnames, styles.wrapper]);
     const checkboxClassNames = classNames(["icon-moon", styles.checkbox], {
@@ -21,22 +24,43 @@ const StarCheckbox = ({
         [styles.indeterminate]: indeterminate,
     });
 
+    const updateTooltipTitle = () => {
+        const text = checked ? "Remove highlight" : "Highlight";
+        setTooltipTitle(text);
+    };
+
+    const handleMouseEnter = () => {
+        setShowTooltip(true);
+    };
+
+    const handleMouseLeave = () => {
+        setShowTooltip(false);
+        updateTooltipTitle();
+    };
+
     return (
         <label className={wrapperClassnames}>
             <span className={styles.container}>
                 <Tooltip
-                    title={checked ? "Remove highlight" : "Highlight"}
+                    title={tooltipTitle}
                     placement="top"
                     mouseEnterDelay={TOOLTIP_DELAY}
                     color={TOOLTIP_COLOR}
+                    open={showTooltip}
+                    onOpenChange={updateTooltipTitle}
                 >
                     <input
                         checked={checked}
                         type="checkbox"
-                        onChange={(e: any) =>
-                            onChange ? onChange(e as CheckboxChangeEvent) : null
-                        }
+                        onChange={(e: any) => {
+                            setShowTooltip(false);
+                            onChange
+                                ? onChange(e as CheckboxChangeEvent)
+                                : null;
+                        }}
                         value={value}
+                        onMouseEnter={handleMouseEnter}
+                        onMouseLeave={handleMouseLeave}
                     />
                 </Tooltip>
                 <span className={checkboxClassNames} />

--- a/src/components/StarCheckbox/index.tsx
+++ b/src/components/StarCheckbox/index.tsx
@@ -54,9 +54,7 @@ const StarCheckbox = ({
                         type="checkbox"
                         onChange={(e: any) => {
                             setShowTooltip(false);
-                            onChange
-                                ? onChange(e as CheckboxChangeEvent)
-                                : null;
+                            onChange?.(e);
                         }}
                         value={value}
                         onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
Time to review:
_Small: 5 minutes_

Problem
=======
Closes #297 specifially criteria 1 and 2
@meganrm already resolved criteria 3 and 4 in previous work.

Solution
========
We need to manage the tooltip open/closed state via a local state so we can keep it closed after a click event, and only update the title text while the tooltip is closed so that the new text doesn't flicker before the tooltip has a chance to hide.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Try the different hide and highlight checkboxes, observe the tooltip behavior: after clicking it should hide until the mouse has left and re-entered.

https://github.com/simularium/simularium-website/assets/24981838/2efef448-aa93-417f-a6eb-67b71e0063e2

