### PR TITLE
feature/viewport button component

### DIFF
--- a/src/components/CameraControls/index.tsx
+++ b/src/components/CameraControls/index.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useState, useRef } from "react";
-import { Button, Tooltip } from "antd";
-import classNames from "classnames";
 import { useHotkeys, useIsHotkeyPressed } from "react-hotkeys-hook";
 
-import { TOOLTIP_COLOR } from "../../constants/index";
 import { ZoomIn, ZoomOut } from "../Icons";
+import ViewportButton from "../ViewportButton";
 
 import styles from "./style.css";
 
@@ -143,178 +141,77 @@ const CameraControls = ({
     }, [keyPressed]);
     return (
         <div className={styles.container}>
-            <div className={styles.zoomButtons}>
-                <Tooltip
-                    placement="left"
-                    title="Zoom in ( &uarr; )"
-                    color={TOOLTIP_COLOR}
-                >
-                    <Button
-                        className={styles.btn}
-                        icon={ZoomIn}
-                        onClick={zoomIn}
-                    />
-                </Tooltip>
-                <Tooltip
-                    placement="left"
-                    title="Zoom out ( &darr; )"
-                    color={TOOLTIP_COLOR}
-                >
-                    <Button
-                        className={styles.btn}
-                        icon={ZoomOut}
-                        onClick={zoomOut}
-                    />
-                </Tooltip>
-            </div>
-            <div className={styles.moveButtons}>
-                <div className={styles.radioGroup}>
-                    <Tooltip
-                        placement="left"
-                        title={
-                            mode === ROTATE ? "Rotate" : "Rotate (hold SHIFT)"
-                        }
-                        color={TOOLTIP_COLOR}
-                    >
-                        {/* Should be radio buttons, but using radio buttons 
-                        detaches keypressed listener after the button is pressed */}
-                        <Button
-                            className={classNames([
-                                { [styles.active]: mode === ROTATE },
-                                styles.radioBtn,
-                            ])}
-                            onClick={() => setMode(ROTATE)}
-                        >
-                            <span
-                                className={classNames([
-                                    "icon-moon",
-                                    "anticon",
-                                    "rotate-icon",
-                                ])}
-                            />
-                        </Button>
-                    </Tooltip>
-                    <Tooltip
-                        placement="left"
-                        title={mode === PAN ? "Pan" : "Pan (hold SHIFT)"}
-                        color={TOOLTIP_COLOR}
-                    >
-                        <Button
-                            className={classNames([
-                                { [styles.active]: mode === PAN },
-                                styles.radioBtn,
-                            ])}
-                            onClick={() => setMode(PAN)}
-                        >
-                            <span
-                                className={classNames([
-                                    "icon-moon",
-                                    "anticon",
-                                    "pan-icon",
-                                ])}
-                            />
-                        </Button>
-                    </Tooltip>
-                </div>
-            </div>
-            <div className={styles.moveButtons}>
-                <div className={styles.radioGroup}>
-                    <Tooltip
-                        placement="left"
-                        title={"Orthographic Camera"}
-                        color={TOOLTIP_COLOR}
-                    >
-                        {/* Should be radio buttons, but using radio buttons 
-                        detaches keypressed listener after the button is pressed */}
-                        <Button
-                            className={classNames([
-                                {
-                                    [styles.active]:
-                                        cameraProjectionType === ORTHOGRAPHIC,
-                                },
-                                styles.radioBtn,
-                            ])}
-                            onClick={() => {
-                                setCameraProjectionType(ORTHOGRAPHIC);
-                            }}
-                            icon={
-                                <span
-                                    className={classNames([
-                                        "icon-moon",
-                                        "anticon",
-                                        "orthographic-icon",
-                                    ])}
-                                />
-                            }
-                        ></Button>
-                    </Tooltip>
-                    <Tooltip
-                        placement="left"
-                        title={"Perspective Camera"}
-                        color={TOOLTIP_COLOR}
-                    >
-                        <Button
-                            className={classNames([
-                                {
-                                    [styles.active]:
-                                        cameraProjectionType === PERSPECTIVE,
-                                },
-                                styles.radioBtn,
-                            ])}
-                            onClick={() => {
-                                setCameraProjectionType(PERSPECTIVE);
-                            }}
-                            icon={
-                                <span
-                                    className={classNames([
-                                        "icon-moon",
-                                        "anticon",
-                                        "perspective-icon",
-                                    ])}
-                                />
-                            }
-                        ></Button>
-                    </Tooltip>
-                </div>
-            </div>
-            <Tooltip placement="left" title="Focus (F)" color={TOOLTIP_COLOR}>
-                <Button
-                    className={classNames([
-                        { [styles.active]: isFocused },
-                        styles.radioBtn,
-                    ])}
-                    onClick={() => {
-                        saveFocusMode(!isFocused);
-                    }}
-                >
-                    <span
-                        className={classNames([
-                            "icon-moon",
-                            "anticon",
-                            "focus-icon",
-                        ])}
-                    />
-                </Button>
-            </Tooltip>
-            <Tooltip
-                placement="left"
-                title="Home view (H)"
-                color={TOOLTIP_COLOR}
-            >
-                <Button
-                    className={styles.btn}
-                    icon={
-                        <span
-                            className={classNames([
-                                "icon-moon",
-                                "anticon",
-                                "reset-icon",
-                            ])}
-                        />
-                    }
-                    onClick={resetCamera}
+            <div className={styles.zoomGroup}>
+                <ViewportButton
+                    tooltipText="Zoom in ( &uarr; )"
+                    tooltipPlacement="left"
+                    icon={ZoomIn}
+                    clickHandler={zoomIn}
                 />
-            </Tooltip>
+                <ViewportButton
+                    tooltipText="Zoom out ( &darr; )"
+                    tooltipPlacement="left"
+                    icon={ZoomOut}
+                    clickHandler={zoomOut}
+                />
+            </div>
+            <div className={styles.radioGroup}>
+                <ViewportButton
+                    tooltipText={
+                        mode === ROTATE ? "Rotate" : "Rotate (hold SHIFT)"
+                    }
+                    tooltipPlacement="left"
+                    icon={"rotate-icon"}
+                    radioGroupPosition={"top"}
+                    clickHandler={() => setMode(ROTATE)}
+                    active={mode === ROTATE}
+                />
+                <ViewportButton
+                    tooltipText={mode === PAN ? "Pan" : "Pan (hold SHIFT)"}
+                    tooltipPlacement="left"
+                    icon={"pan-icon"}
+                    radioGroupPosition={"bottom"}
+                    clickHandler={() => setMode(PAN)}
+                    active={mode === PAN}
+                />
+            </div>
+            <ViewportButton
+                tooltipText={"Focus (F)"}
+                tooltipPlacement="left"
+                icon={"focus-icon"}
+                clickHandler={() => {
+                    saveFocusMode(!isFocused);
+                }}
+                active={isFocused}
+            />
+            <div className={styles.radioGroup}>
+                <ViewportButton
+                    tooltipText={"Orthographic Camera"}
+                    tooltipPlacement="left"
+                    icon={"orthographic-icon"}
+                    radioGroupPosition={"top"}
+                    clickHandler={() => {
+                        setCameraProjectionType(ORTHOGRAPHIC);
+                    }}
+                    active={cameraProjectionType === ORTHOGRAPHIC}
+                />
+                <ViewportButton
+                    tooltipText={"Perspective Camera"}
+                    tooltipPlacement="left"
+                    icon={"perspective-icon"}
+                    radioGroupPosition={"bottom"}
+                    clickHandler={() => {
+                        setCameraProjectionType(PERSPECTIVE);
+                    }}
+                    active={cameraProjectionType === PERSPECTIVE}
+                />
+            </div>
+            <ViewportButton
+                tooltipText={"Home view (H)"}
+                tooltipPlacement="left"
+                icon={"reset-icon"}
+                clickHandler={resetCamera}
+            />
         </div>
     );
 };

--- a/src/components/CameraControls/style.css
+++ b/src/components/CameraControls/style.css
@@ -5,92 +5,17 @@
     bottom: 0;
     right: 20px;
     justify-content: space-evenly;
-    gap: 12px;
+    gap: 10px;
     margin-bottom: 20px;
 }
 
-.container :global(.ant-btn) {
-    height: 26px;
-    width: 26px;
-    background-color: var(--viewer-btn-bg-default);
+.zoom-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
 .radio-group {
     display: flex;
-    flex-flow: column;
-    justify-content: space-evenly;
-}
-
-.zoom-buttons {
-    display: flex;
     flex-direction: column;
-    justify-content: space-evenly;
-    height: 60px;
-}
-
-.btn {
-    background-color: var(--viewer-btn-bg-default);
-    color: var(--viewer-btn-color-default);
-    border-radius: 3px!important;
-    height: 26px !important;
-    width: 26px !important;
-}
-
-.radio-btn {
-    padding: 0 2px!important;
-    width: 26px;
-    height: 26px;
-    border-left-width: 1px;
-    border: none;
-}
-
-.radio-btn.active {
-    color: var(--viewer-btn-color-default) !important;
-    background-color: var(--viewer-btn-bg-default) !important;
-    border: 1px solid var(--viewer-btn-border-active) !important;
-}
-
-.radio-btn:hover {
-    color: var(--viewer-btn-color-default);
-    background-color: var(--viewer-btn-bg-hover)!important;
-}
-
-.radio-group .radio-btn:not(:first-child) {
-    border-top: 0px;
-}
-
-.radio-group .radio-btn:first-child {
-    border-radius: 3px 3px 0px 0px;
-}
-
-.radio-group .radio-btn:last-child {
-    border-radius: 0px 0px 3px 3px;
-}
-
-.btn:hover {
-    color: var(--viewer-btn-color-default);
-    background-color: var(--viewer-btn-bg-hover);
-    border: 1px solid var(--viewer-btn-border-active) !important;
-}
-
-.btn:focus {
-    background-color: var(--dark-theme-btn-bg);
-    color: var(--dark-theme-btn-color);
-}
-
-.btn:hover:focus {
-    color: var(--viewer-btn-color-default);
-    background-color: var(--viewer-btn-bg-hover);
-}
-
-.btn[disabled] {
-    background-color: var(--viewer-btn-bg-disabled);
-    color: var(--viewer-btn-color-disabled);
-
-}
-
-.container .anticon svg {
-    height: 24px;
-    width: 24px;
-    color: var(--viewer-btn-color-default);
 }

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -1,14 +1,15 @@
 import React, { KeyboardEvent, useState } from "react";
-import { Button, Slider, Tooltip, InputNumber } from "antd";
+import { Slider, InputNumber } from "antd";
 import classNames from "classnames";
 import { compareTimes } from "@aics/simularium-viewer";
 
-import { TOOLTIP_COLOR } from "../../constants/index";
-import Icons from "../Icons";
 import { DisplayTimes } from "../../containers/ViewerPanel/types";
 import { TimeUnits } from "../../state/trajectory/types";
+import { Pause, Play } from "../Icons";
+import ViewportButton from "../ViewportButton";
 
 import styles from "./style.css";
+
 interface PlayBackProps {
     playHandler: (timeOverride?: number) => void;
     time: number;
@@ -106,8 +107,6 @@ const PlayBackControls = ({
         return `${displayTimes.maxNumChars + 1}ch`;
     };
 
-    const btnClassNames = classNames([styles.item, styles.btn]);
-
     // Disable step back button if time - timeStep < firstFrameTime
     const isStepBackDisabled =
         compareTimes(time - timeStep, firstFrameTime, timeStep) === -1;
@@ -117,80 +116,40 @@ const PlayBackControls = ({
 
     return (
         <div className={styles.container}>
-            <Tooltip
-                placement="top"
-                title="Skip 1 frame back"
-                color={TOOLTIP_COLOR}
-            >
-                <Button
-                    className={classNames([
-                        btnClassNames,
-                        { [styles.customStepButton]: !loading },
-                    ])}
-                    onClick={prevHandler}
+            <div className={styles.buttonContainer}>
+                <ViewportButton
+                    tooltipText="Skip 1 frame back"
+                    tooltipPlacement="top"
+                    icon={"step-back-icon"}
+                    clickHandler={prevHandler}
                     disabled={isStepBackDisabled || loading || isEmpty}
                     loading={loading}
-                >
-                    {/* if loading, antd will show loading icon, otherwise, show our custom svg */}
-                    {!loading && (
-                        <span
-                            className={classNames([
-                                "icon-moon",
-                                "anticon",
-                                "step-back-icon",
-                            ])}
-                        />
-                    )}
-                </Button>
-            </Tooltip>
-            <Tooltip
-                placement="top"
-                title={isPlaying ? "Pause" : "Play"}
-                color={TOOLTIP_COLOR}
-            >
-                <Button
-                    className={classNames([
-                        btnClassNames,
-                        styles.buttonSpacing,
-                    ])}
-                    icon={isPlaying ? Icons.Pause : Icons.Play}
-                    onClick={isPlaying ? pauseHandler : () => playHandler()}
-                    loading={loading}
-                    disabled={isEmpty}
                 />
-            </Tooltip>
-            <Tooltip
-                placement="top"
-                title="Skip 1 frame ahead"
-                color={TOOLTIP_COLOR}
-            >
-                <Button
-                    className={classNames([
-                        btnClassNames,
-                        { [styles.customStepButton]: !loading },
-                    ])}
-                    onClick={nextHandler}
+                <ViewportButton
+                    tooltipText={isPlaying ? "Pause" : "Play"}
+                    tooltipPlacement="top"
+                    icon={isPlaying ? Pause : Play}
+                    clickHandler={
+                        isPlaying ? pauseHandler : () => playHandler()
+                    }
                     disabled={isStepForwardDisabled || loading || isEmpty}
                     loading={loading}
-                >
-                    {/* if loading, antd will show loading icon, otherwise, show our custom svg */}
-                    {!loading && (
-                        <span
-                            className={classNames([
-                                "icon-moon",
-                                "anticon",
-                                "step-forward-icon",
-                            ])}
-                        />
-                    )}
-                </Button>
-            </Tooltip>
+                />
+                <ViewportButton
+                    tooltipText={"Skip 1 frame ahead"}
+                    tooltipPlacement="top"
+                    icon={"step-forward-icon"}
+                    clickHandler={nextHandler}
+                    disabled={isStepForwardDisabled || loading || isEmpty}
+                    loading={loading}
+                />
+            </div>
             <Slider
                 value={time}
                 onChange={handleTimeChange}
                 onAfterChange={handleSliderMouseUp}
                 tooltip={{ open: false }}
-                className={[styles.slider, styles.item].join(" ")}
+                className={classNames(styles.slider, styles.item)}
                 step={timeStep}
                 min={firstFrameTime}
                 max={lastFrameTime}
@@ -213,23 +172,15 @@ const PlayBackControls = ({
                     {timeUnits ? timeUnits.name : "s"}
                 </span>
             </div>
-            <Tooltip
-                placement="top"
-                title={isLooping ? "Turn off looping" : "Turn on looping"}
-                color={TOOLTIP_COLOR}
-                arrowPointAtCenter
-            >
-                <Button
-                    className={classNames([
-                        btnClassNames,
-                        { [styles.active]: isLooping },
-                    ])}
-                    icon={Icons.LoopOutlined}
-                    onClick={loopHandler}
-                    loading={loading}
-                    disabled={isEmpty}
-                />
-            </Tooltip>
+            <ViewportButton
+                tooltipText={isLooping ? "Turn off looping" : "Turn on looping"}
+                tooltipPlacement="top"
+                icon={"looping-icon"}
+                clickHandler={loopHandler}
+                disabled={isEmpty}
+                active={isLooping}
+                loading={loading}
+            />
         </div>
     );
 };

--- a/src/components/PlaybackControls/style.css
+++ b/src/components/PlaybackControls/style.css
@@ -1,6 +1,7 @@
 .container {
     position: absolute;
     display: flex;
+    gap: 8px;
     bottom: 0;
     right: 25%;
     width: 50%;
@@ -8,12 +9,17 @@
     margin-bottom: 20px;
 }
 
+.button-container {
+    display: flex;
+    gap: 4px;
+}
+
 .container :global(.ant-input-number) {
     background-color: transparent;
 }
 
 .container :global(.ant-input-number input) {
-    color: var(--viewer-btn-color-default);
+    color: var(--dark-theme-viewport-button-color);
     padding: 0 3px;
 }
 
@@ -22,51 +28,13 @@
     display: none;
 }
 
-.container .btn, .container :global(.ant-btn) {
-    /* this works to set height and other qualties  */
-    height: 26px;
-    width: 26px;
-    border-radius: 3px;
-    background-color: var(--viewer-btn-bg-default);
-    color: var(--viewer-btn-color-default);
-    border: none;
-}
-
-.container .btn:hover {
-    color: var(--viewer-btn-color-default);
-    background-color: var(--viewer-btn-bg-hover);
-    border: 1px solid var(--viewer-btn-border-active);
-}
-
-.container .btn.active {
-    color: var(--viewer-btn-color-default);
-    background-color: var(--viewer-btn-bg-default);
-    border: 1px solid var(--viewer-btn-border-active);
-}
-
-.container .btn.active:hover {
-    color: var(--viewer-btn-color-default);
-    background-color: var(--viewer-btn-bg-hover);
-    border: 1px solid var(--viewer-btn-border-active);
-}
-
-.container .btn button[disabled] {
-    background-color: var(--viewer-btn-bg-disabled);
-    color: var(--viewer-btn-color-disabled);
-}
-
-.container .button-spacing {
-    margin-left: 4px;
-    margin-right: 4px;
-}
-
 .container .slider {
     flex: 3;
     margin: auto 10px;
 }
 
 .container .slider :global(.ant-slider-track) {
-    background-color: var(--viewer-btn-color-default);
+    background-color: var(--dark-theme-slider-handle-color);
 }
 
 .container .slider :global(.ant-slider-track),
@@ -75,7 +43,7 @@
 }
 
 .container .slider :global(.ant-slider-handle) {
-    background-color: var(--viewer-btn-color-default);
+    background-color: var(--dark-theme-slider-handle-color);
     border: none;
     height: 10px;
     width: 10px;
@@ -88,8 +56,8 @@
 
 .time {
     font-weight: 300;
-    background-color: var(--viewer-btn-bg-default);
-    color: var(--viewer-btn-color-default);
+    background-color: var(--dark-theme-viewport-button-bg);
+    color: var(--dark-theme-viewport-button-color);
     height: 26px;
     min-width: 100px;
     padding: 1px 7px 4px 7px;
@@ -99,23 +67,5 @@
 }
 
 .lastFrameTime {
-    color: var(--dark-theme-btn-color-dim);
-}
-
-.custom-step-button,
-.custom-step-button :global(.ant-btn) {
-    padding: 0;
-    width: 24px;
-    height: 24px;
-}
-
-.container .anticon svg {
-    height: 24px;
-    width: 24px;
-    color: var(--viewer-btn-color-default);
-}
-
-.container :global(.ant-btn-loading-icon) {
-    color: var(--viewer-btn-color-default);
-    margin: auto 2px;
+    color: var(--dark-theme-dim-color);
 }

--- a/src/components/ScaleBar/style.css
+++ b/src/components/ScaleBar/style.css
@@ -16,7 +16,7 @@
 .text {
     font-size: 12px;
     font-weight: 300;
-    color: var(--dark-theme-btn-color);
+    color: var(--dark-theme-dim-color);
 }
 
 .container img {

--- a/src/components/ViewportButton/index.tsx
+++ b/src/components/ViewportButton/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Button, ButtonProps, Tooltip } from "antd";
+import { Button, ButtonProps, Tooltip, TooltipProps } from "antd";
 import classNames from "classnames";
 
 import { TOOLTIP_COLOR } from "../../constants";
@@ -7,7 +7,7 @@ import styles from "./style.css";
 
 interface ViewportButtonProps extends ButtonProps {
     tooltipText?: string;
-    tooltipPlacement?: "top" | "bottom" | "left" | "right";
+    tooltipPlacement?: TooltipProps["placement"];
     icon?: ReactNode | string; // When using an icomoon icon, pass the icon name as defined in selectors in src/styles.css
     radioGroupPosition?: "top" | "bottom";
     clickHandler?: () => void;

--- a/src/components/ViewportButton/index.tsx
+++ b/src/components/ViewportButton/index.tsx
@@ -1,0 +1,80 @@
+import React, { ReactNode } from "react";
+import { Button, ButtonProps, Tooltip } from "antd";
+import classNames from "classnames";
+
+import { TOOLTIP_COLOR } from "../../constants";
+import styles from "./style.css";
+
+interface ViewportButtonProps extends ButtonProps {
+    tooltipText?: string;
+    tooltipPlacement?: "top" | "bottom" | "left" | "right";
+    icon?: ReactNode | string; // When using an icomoon icon, pass the icon name as defined in selectors in src/styles.css
+    radioGroupPosition?: "top" | "bottom";
+    clickHandler?: () => void;
+    disabled?: boolean;
+    active?: boolean;
+    loading?: boolean;
+}
+
+const ViewportButton: React.FC<ViewportButtonProps> = ({
+    className,
+    tooltipText,
+    tooltipPlacement,
+    icon,
+    clickHandler,
+    disabled,
+    loading,
+    active,
+    radioGroupPosition,
+    ...props
+}) => {
+    const getIcon = () => {
+        // if icon is a react element, return it as is
+        // if its a string provide it as a class name to render the appropriate icon
+        // from global style selectors
+        if (React.isValidElement(icon)) {
+            return icon;
+        }
+        if (typeof icon === "string") {
+            return (
+                <span className={classNames(["icon-moon", "anticon", icon])} />
+            );
+        }
+    };
+
+    const radioGroupStyle = (): string => {
+        switch (radioGroupPosition) {
+            case "top":
+                return styles.radioGroupTop;
+            case "bottom":
+                return styles.radioGroupBottom;
+            default:
+                return "";
+        }
+    };
+
+    const buttonClassNames = classNames([
+        className,
+        styles.viewportButton,
+        disabled && styles.disabled,
+        active && styles.active,
+        radioGroupPosition && radioGroupStyle(),
+    ]);
+    return (
+        <Tooltip
+            placement={tooltipPlacement}
+            title={!disabled && tooltipText}
+            color={TOOLTIP_COLOR}
+        >
+            <Button
+                {...props}
+                className={buttonClassNames}
+                onClick={clickHandler}
+                loading={loading}
+                icon={getIcon()}
+            />
+        </Tooltip>
+    );
+};
+
+export default ViewportButton;

--- a/src/components/ViewportButton/style.css
+++ b/src/components/ViewportButton/style.css
@@ -1,0 +1,38 @@
+.viewport-button:global(.ant-btn),
+.viewport-button:global(.ant-btn:focus) {
+    background-color: var(--dark-theme-viewport-button-bg);
+    border-color: var(--dark-theme-viewport-button-border);
+    border-radius: 3px;
+    color: var(--dark-theme-viewport-button-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 26px;
+    width: 26px;
+    min-width: 26px;
+}
+
+.viewport-button:global(.ant-btn).disabled {
+    color: var(--dark-theme-viewport-button-disabled-color);
+    cursor: not-allowed;
+}
+
+.viewport-button:global(.ant-btn).active {
+    border-color: var(--dark-theme-viewport-button-toggle-border);
+}
+
+.viewport-button:global(.ant-btn:hover):not(.disabled) {
+    background-color: var(--dark-theme-viewport-button-hover-bg);
+}
+
+.viewport-button:global(.ant-btn:hover):not(.disabled).active {
+    border-color: var(--dark-theme-viewport-button-toggle-border);
+}
+
+.viewport-button:global(.ant-btn).radio-group-top {
+    border-radius: 3px 3px 0px 0px;
+}
+
+.viewport-button:global(.ant-btn).radio-group-bottom {
+    border-radius: 0px 0px 3px 3px;
+}

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -10,7 +10,6 @@
     --white-two: #d3d3d3;
     --white-three: #d8d8d8;
     --white-four: #f2f2f2;
-    --white-six: #e7e7e7;
     --transparent-white: rgba(255, 255, 255, 0.65);
     --dim-gray: #383838;
     --dim-gray-two: #6e6e6e;
@@ -29,8 +28,7 @@
     --medium-gray: #aeaeae;
     --dark-blue-gray: #69738a;
     --brick-red: #d14040;
-    /* Non-theme variables */
-    --icon-moon-color: var(--white-three);
+    /* non-theme variables */
     --star-checkbox-bg: var(--grayish-brown);
     --footer-bg: var(--dark-three);
     --footer-text: var(--warm-gray);
@@ -38,21 +36,25 @@
     --footer-link: var(--blue);
     --input-border-highlight: var(--heather);
     --color-picker-tooltip: var(--dark-blue-gray);
-    --viewer-btn-bg-default: var(--dark-three);
-    --viewer-btn-bg-hover: var(--purplish-gray);
-    --viewer-btn-bg-disabled: var(--dark-three);
-    --viewer-btn-border-active: var(--white-three);
-    --viewer-btn-color-default: var(--white-three);
-    --viewer-btn-color-disabled: var(--grayish-brown);
     --cancel-icon-color: var(--brick-red);
     /* Dark theme */
-    --dark-theme-primary-color: var(--baby-purple);
+    /* viewport-buttons */
+    --dark-theme-viewport-button-bg: var(--dark-three);
+    --dark-theme-viewport-button-border: var(--dark-three);
+    --dark-theme-viewport-button-color: var(--white-three);
+    --dark-theme-viewport-button-toggle-border: var(--dim-gray-two);
+    --dark-theme-viewport-button-hover-bg: var(--purplish-gray);
+    --dark-theme-viewport-button-disabled-color: var(--dim-gray-two);
+    /* dark theme general/uncategorized */
     --dark-theme-body-bg: var(--black);
     --dark-theme-header-bg: var(--dark-three);
+    --dark-theme-text-color: var(--off-white);
+    --dark-theme-dim-color: var(--text-gray);
+    --dark-theme-slider-handle-color: var(--white-three);
+    --dark-theme-primary-color: var(--baby-purple);
     --dark-theme-header-text: var(--text-gray);
     --dark-theme-component-bg: var(--dark-four);
     --dark-theme-input-border: var(--white-two);
-    --dark-theme-text-color: var(--off-white);
     --dark-theme-popover-text: var(--white-two);
     --dark-theme-menu-text-color: var(--transparent-white);
     --dark-theme-menu-text-hover: var(--pure-white);
@@ -62,11 +64,7 @@
     --dark-theme-sidebar-header-bg: var(--dark-three);
     --dark-theme-sidebar-item-bg: var(--dark-two);
     --dark-theme-sidebar-text: var(--white-two);
-    --dark-theme-btn-bg: var(--dark-three);
-    --dark-theme-btn-color: var(--white-three);
-    --dark-theme-btn-color-dim: var(--text-gray);
     --dark-theme-btn-hover-bg: var(--grayish-brown);
-    --dark-theme-btn-primary: var(--baby-purple);
     --dark-theme-tooltip-bg: var(--charcoal-gray);
     --dark-theme-version-badge-purple: var(--dark-five);
     --dark-theme-star-icon-color: var(--warm-gray);


### PR DESCRIPTION
### Time to review:
_Medium_
_Design review with UX complete._

### Problem
Viewport buttons (camera and playback controls) do not match current style guidance.
The code for these buttons and their stylesheets is not DRY.

### Solution
Create `ViewportButton` component. Each `ViewportButton` wraps a button in a tooltip and takes a short list of custom props that get it styled correctly. Implementing components (playback controls, camera controls, forthcoming record movies component) are concise and readable.

Relevant re-organizing and re-naming is ongoing in `colors.css`. It's a pain, but if any reviewers would like to use it I have a python script that scans the repo for unused css vars and css properties that use variables that aren't actually defined (there were several!) that is making this somewhat less painful T_T

* Bug fix (non-breaking change which fixes an issue) (style issues)
* New feature (non-breaking change which adds functionality) (wrapper component)


Steps to Verify:
----------------
1. Confirm styling is correct for buttons in default, hover, and active states.

Screenshots (optional):
-----------------------
Old:
<img width="667" alt="Screenshot 2024-03-13 at 12 06 29 PM" src="https://github.com/simularium/simularium-website/assets/24981838/25dce55a-7511-4019-b507-b7d754e4de6f">
New:
<img width="568" alt="Screenshot 2024-03-13 at 12 06 47 PM" src="https://github.com/simularium/simularium-website/assets/24981838/7fceeecf-34c2-40f5-8ac0-b8e16f0a64c2">
