### PR TITLE
autoconversion: fix/domnesting error

### DIFF
--- a/src/components/NoTrajectoriesText/index.tsx
+++ b/src/components/NoTrajectoriesText/index.tsx
@@ -57,10 +57,7 @@ const NoTrajectoriesText = ({
                             <li>SpringSaLaD</li>
                         </ul>
                     </li> */}
-                    <li>
-                        {" "}
-                        Import a Smoldyn file through the Load Model menu.{" "}
-                    </li>
+                    <li>Import a Smoldyn file through the Load Model menu.</li>
                     <li>
                         Convert other file types using{" "}
                         <a

--- a/src/components/NoTrajectoriesText/index.tsx
+++ b/src/components/NoTrajectoriesText/index.tsx
@@ -28,7 +28,7 @@ const NoTrajectoriesText = ({
     return (
         <div className={styles.container}>
             <h3>Ways to get started:</h3>
-            <p>
+            <div>
                 <ol>
                     <li>Drag and drop a .simularium file onto this window</li>
                     <li>
@@ -43,7 +43,11 @@ const NoTrajectoriesText = ({
                         now or browse examples from the{" "}
                         <a href="/#try-simularium-now">start page</a>
                     </li>
-                    <li>
+                    {/* 
+                    todo: restore this text as autoconversion handles
+                    more file types
+                    */}
+                    {/* <li>
                         Import common file types through the Load Model menu
                         button, including:
                         <ul>
@@ -52,6 +56,10 @@ const NoTrajectoriesText = ({
                             <li>cellPACK</li>
                             <li>SpringSaLaD</li>
                         </ul>
+                    </li> */}
+                    <li>
+                        {" "}
+                        Import a Smoldyn file through the Load Model menu.{" "}
                     </li>
                     <li>
                         Convert other file types using{" "}
@@ -64,7 +72,7 @@ const NoTrajectoriesText = ({
                         </a>
                     </li>
                 </ol>
-            </p>
+            </div>
         </div>
     );
 };

--- a/src/components/NoTrajectoriesText/style.css
+++ b/src/components/NoTrajectoriesText/style.css
@@ -2,20 +2,17 @@
     margin: 1em;
 }
 
-.container p, .container h3 {
+.container div, .container h3 {
     color: var(--dark-theme-sidebar-text);
-    margin-bottom: 1.5em;
     font-size: 16px;
+    margin-bottom: 1.5em;
 }
 
 .container h3 {
     font-weight: 600;
 }
 
-.container p {
-    font-weight: 200;
-}
-
 .container ul, .container ol {
     padding-left: 20px;
+    font-weight: 200;
 }


### PR DESCRIPTION
Time estimate or Size
=======
_xsmall_

Problem
=======
Getting a validate dom nesting error because list elements are inside a `p` tag.
Also the text is not true, MVP will only convert Smoldyn so changing to reflect that and leaving UX's intended text in to restore as we add other converters.


Solution
========
`p` -> `div`, adjusted styles

* Bug fix (non-breaking change which fixes an issue)
