### PR TITLE
autoconversion: fix/refactor after merging main

### DIFF
--- a/src/components/CameraControls/style.css
+++ b/src/components/CameraControls/style.css
@@ -9,12 +9,6 @@
     margin-bottom: 20px;
 }
 
-.container :global(.ant-btn) {
-    height: 26px;
-    width: 26px;
-    background-color: var(--viewer-btn-bg-default);
-}
-
 .zoom-group {
     display: flex;
     flex-direction: column;

--- a/src/components/ConversionCancelModal/index.tsx
+++ b/src/components/ConversionCancelModal/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from "antd";
 import React from "react";
+import classNames from "classnames";
 
 import CustomModal from "../CustomModal";
 
@@ -16,22 +17,24 @@ const ConversionCancelModal: React.FC<ConversionCancelModalProps> = ({
 }) => {
     const footerButtons = (
         <>
-            <Button onClick={continueProcessing}>No</Button>
-            <Button type="primary" onClick={cancelProcessing}>
+            <Button
+                className={classNames("primary-button", styles.wideButton)}
+                onClick={cancelProcessing}
+            >
                 Yes, cancel
+            </Button>
+            <Button className="secondary-button" onClick={continueProcessing}>
+                No
             </Button>
         </>
     );
 
     return (
         <CustomModal
-            className={styles.cancelModal}
-            title="Cancel file import"
-            open
-            footer={footerButtons}
+            titleText="Cancel file import"
+            footerButtons={footerButtons}
             width={341}
-            centered
-            onCancel={continueProcessing}
+            closeHandler={continueProcessing}
         >
             <p>
                 Information provided will not be saved. Are you sure you want to

--- a/src/components/ConversionCancelModal/style.css
+++ b/src/components/ConversionCancelModal/style.css
@@ -1,7 +1,3 @@
-.cancel-modal p {
-    font-size: 14px;
-}
-
-.cancel-modal :global(.ant-modal-footer) {
-    background-color: var(--modal-content-bg);
+:global(.ant-btn):global(.primary-button).wide-button {
+    width: 114px;
 }

--- a/src/components/ConversionFileErrorModal/index.tsx
+++ b/src/components/ConversionFileErrorModal/index.tsx
@@ -30,15 +30,14 @@ const ConversionFileErrorModal: React.FC<ConversionFileErrorModalProps> = ({
             footerButtons={footerButton}
             closeHandler={closeModal}
         >
-            {/* <> */}
             <p className={classNames(styles.warningText)}>
-                {Exclamation}{" "}
+                {Exclamation}
                 {` We're sorry, there was a problem importing your file.`}
             </p>
             <p>
                 {`You may want to double check that the file you selected is a
-                    valid`}{" "}
-                {engineType}{" "}
+                    valid `}
+                {engineType}
                 {` file and try again. For further
                     assistance, please visit `}
                 <a
@@ -49,7 +48,6 @@ const ConversionFileErrorModal: React.FC<ConversionFileErrorModalProps> = ({
                     The Allen Cell Discussion Forum.
                 </a>
             </p>
-            {/* </> */}
         </CustomModal>
     );
 };

--- a/src/components/ConversionFileErrorModal/index.tsx
+++ b/src/components/ConversionFileErrorModal/index.tsx
@@ -1,8 +1,10 @@
 import { Button } from "antd";
 import React from "react";
+import classNames from "classnames";
 
-import CustomModal from "../CustomModal";
 import { AvailableEngines } from "../../state/trajectory/conversion-data-types";
+import CustomModal from "../CustomModal";
+import { Exclamation } from "../Icons";
 
 import styles from "./style.css";
 
@@ -16,7 +18,7 @@ const ConversionFileErrorModal: React.FC<ConversionFileErrorModalProps> = ({
     engineType,
 }) => {
     const footerButton = (
-        <Button type="primary" onClick={closeModal}>
+        <Button className="primary-button" onClick={closeModal}>
             OK
         </Button>
     );
@@ -24,22 +26,21 @@ const ConversionFileErrorModal: React.FC<ConversionFileErrorModalProps> = ({
     return (
         <CustomModal
             className={styles.errorModal}
-            title="File import cannot be completed"
-            open
-            footer={footerButton}
-            width={426}
-            centered
-            onCancel={closeModal}
+            titleText="File import cannot be completed"
+            footerButtons={footerButton}
+            closeHandler={closeModal}
         >
-            <div>
-                <p className={styles.warningText}>
-                    {"We're sorry, there was a problem importing your file."}
-                </p>
-                <p>
-                    You may want to double check that the file you selected is a
-                    valid {engineType} file and try again. For further
-                    assistance, please visit
-                </p>
+            {/* <> */}
+            <p className={classNames(styles.warningText)}>
+                {Exclamation}{" "}
+                {` We're sorry, there was a problem importing your file.`}
+            </p>
+            <p>
+                {`You may want to double check that the file you selected is a
+                    valid`}{" "}
+                {engineType}{" "}
+                {` file and try again. For further
+                    assistance, please visit `}
                 <a
                     href="https://forum.allencell.org/"
                     target="_blank"
@@ -47,7 +48,8 @@ const ConversionFileErrorModal: React.FC<ConversionFileErrorModalProps> = ({
                 >
                     The Allen Cell Discussion Forum.
                 </a>
-            </div>
+            </p>
+            {/* </> */}
         </CustomModal>
     );
 };

--- a/src/components/ConversionFileErrorModal/style.css
+++ b/src/components/ConversionFileErrorModal/style.css
@@ -1,23 +1,4 @@
-.error-modal :global(.ant-modal-title) {
-    font-size: 14px;
-    font-weight: 400;
-}
-
-.error-modal :global(.ant-modal-body) {
-    font-size: 14px;
-    padding: 15px 15px 0px 15px;
-}
-
 .error-modal .warning-text {
-    color: var(--warning-text-color);
-    padding: 10px 0px;
-}
-
-.error-modal :global(.ant-modal-footer) {
-    background-color: var(--modal-content-bg);
-    padding: 16px 12px 12px;
-}
-
-.error-modal :global(.ant-modal-header) {
-    padding: 12px 24px;
+    color: var(--cancel-icon-color);
+    padding-bottom: 0.5em;
 }

--- a/src/components/ConversionProcessingOverlay/index.tsx
+++ b/src/components/ConversionProcessingOverlay/index.tsx
@@ -50,7 +50,7 @@ const ConversionProcessingOverlay = ({
                 </div>
                 <h3>Open another instance of Simularium </h3>
                 <Button
-                    className={styles.button}
+                    className="secondary-button"
                     href={`https://simularium.allencell.org/viewer`}
                     target="_blank"
                 >
@@ -61,7 +61,7 @@ const ConversionProcessingOverlay = ({
                 <Divider> </Divider>
             </div>
             <Button
-                className={styles.button}
+                className="secondary-button"
                 onClick={() => setCancelModalOpen(true)}
             >
                 Cancel file import

--- a/src/components/ConversionProcessingOverlay/style.css
+++ b/src/components/ConversionProcessingOverlay/style.css
@@ -3,7 +3,7 @@
     height: calc(100vh - var(--header-height));
     width: 100%;
     z-index: 300;
-    background-color: var(--overlay-purple);
+    background-color: var(--light-theme-bg);
     display: flex;
     flex-flow: column;
     align-items: center;
@@ -11,12 +11,12 @@
 }
 
 .title {
-    color: var(--light-theme-text-primary-color);
+    color: var(--light-theme-color);
     font-weight: 700;
 }
 
 .content {
-    color: var(--light-theme-text-primary-color);
+    color: var(--light-theme-color);
     display: flex;
     flex-flow: column;
     align-items: center;
@@ -44,9 +44,5 @@
 }
 
 .divider-container :global(.ant-divider) {
-    background-color: var(--heather);
-}
-
-.button {
-    border: 1.75px solid var(--dark-four);
+    background-color: var(--light-theme-divider);
 }

--- a/src/components/ConversionServerErrorModal/index.tsx
+++ b/src/components/ConversionServerErrorModal/index.tsx
@@ -27,7 +27,7 @@ const ConversionServerErrorModal: React.FC<ConversionServerErrorModalProps> = ({
             closeHandler={closeModal}
         >
             <p className={styles.warningText}>
-                {Exclamation}{" "}
+                {Exclamation}
                 {` We're sorry, the server is currently
                 experiencing an issue.`}
             </p>

--- a/src/components/ConversionServerErrorModal/index.tsx
+++ b/src/components/ConversionServerErrorModal/index.tsx
@@ -1,5 +1,5 @@
-import { Button } from "antd";
 import React from "react";
+import { Button } from "antd";
 
 import CustomModal from "../CustomModal";
 import { Exclamation } from "../Icons";
@@ -13,26 +13,27 @@ interface ConversionServerErrorModalProps {
 const ConversionServerErrorModal: React.FC<ConversionServerErrorModalProps> = ({
     closeModal,
 }) => {
+    const footerButtons = (
+        <Button className="primary-button" onClick={closeModal}>
+            OK
+        </Button>
+    );
+
     return (
         <CustomModal
             className={styles.serverErrorModal}
-            title="File import cannot be completed"
-            open
-            footer={
-                <Button type="primary" onClick={closeModal}>
-                    OK
-                </Button>
-            }
-            centered
-            onCancel={closeModal}
+            titleText="File import cannot be completed"
+            footerButtons={footerButtons}
+            closeHandler={closeModal}
         >
             <p className={styles.warningText}>
-                {Exclamation} We&apos;re sorry, the server is currently
-                experiencing an issue.
+                {Exclamation}{" "}
+                {` We're sorry, the server is currently
+                experiencing an issue.`}
             </p>
             <p>
-                Please try again at a later time. For further assistance, please
-                visit
+                {`Please try again at a later time. For further assistance, please
+                visit `}
                 <a
                     href="https://forum.allencell.org/"
                     target="_blank"

--- a/src/components/ConversionServerErrorModal/style.css
+++ b/src/components/ConversionServerErrorModal/style.css
@@ -1,35 +1,4 @@
-.server-error-modal :global(.ant-modal-content) {
-    width: 425px;
-}
-
-.server-error-modal :global(.ant-modal-close-x) {
-    /* specifying here prevents hover behavior */
-    color: var(--light-theme-modal-close-x);
-    font-size: 12px;
-    position: relative;
-    top: -3px;
-}
-
-.server-error-modal  :global(.ant-modal-header) {
-    padding: 12px 24px;
-}
-
-.server-error-modal :global(.ant-modal-title) {
-    font-size: 14px;
-    font-weight: 400;
-}
-
-.server-error-modal :global(.ant-modal-body) {
-    font-size: 14px;
-    padding: 20px 20px 0px;
-}
-
 .server-error-modal .warning-text {
-    color: var(--warning-text-color);
-    padding-bottom: 1px;
-}
-
-.server-error-modal :global(.ant-modal-footer) {
-    background-color: var(--modal-content-bg);
-    padding: 6px 16px 12px;
+    color: var(--cancel-icon-color);
+    padding-bottom: 0.5em;
 }

--- a/src/components/CustomModal/index.tsx
+++ b/src/components/CustomModal/index.tsx
@@ -4,7 +4,6 @@ import classNames from "classnames";
 
 import theme from "../theme/light-theme.css";
 import styles from "./style.css";
-import theme from "../theme/light-theme.css";
 
 type OmittedProps =
     | "onCancel"

--- a/src/components/CustomModal/style.css
+++ b/src/components/CustomModal/style.css
@@ -34,6 +34,10 @@
     padding: 24px 24px 10px 24px;
 }
 
+.modal :global(.ant-modal-body) p {
+    margin-bottom: 0px;
+}
+
 .modal.divider :global(.ant-modal-body)  {
     padding: 24px;
 }

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -15,8 +15,6 @@ import NavButton from "../NavButton";
 
 import styles from "./style.css";
 
-import VersionModal from "../VersionModal";
-
 const HelpMenu = (): JSX.Element => {
     const [modalVisible, setModalVisible] = React.useState(false);
 

--- a/src/components/LoadFileMenu/index.tsx
+++ b/src/components/LoadFileMenu/index.tsx
@@ -116,19 +116,20 @@ const LoadFileMenu = ({
         },
     ];
 
+    const isDisabled = isBuffering || conversionStatus !== CONVERSION_INACTIVE;
+
     return (
         <>
             <Dropdown
                 menu={{ items, theme: "dark", className: styles.menu }}
                 placement="bottomRight"
-                disabled={
-                    isBuffering || conversionStatus !== CONVERSION_INACTIVE
-                }
+                disabled={isDisabled}
             >
                 <NavButton
                     titleText={"Load model"}
                     icon={DownArrow}
                     buttonType="primary"
+                    isDisabled={isDisabled}
                 />
             </Dropdown>
             {/* 

--- a/src/containers/AppHeader/style.css
+++ b/src/containers/AppHeader/style.css
@@ -47,11 +47,6 @@
     color: var(--text-gray);
 }
 
-.pipe {
-    padding-left: 2px;
-    color: var(--text-gray);
-}
-
 /* For large screens only */
 @media screen and (min-width: 768px) {
     .page-header {

--- a/src/containers/ConversionForm/index.tsx
+++ b/src/containers/ConversionForm/index.tsx
@@ -225,7 +225,7 @@ const ConversionForm = ({
                             handleFileSelection(file);
                         }}
                     >
-                        <Button type="default">Select file</Button>
+                        <Button className="primary-button">Select file</Button>
                     </Upload>
                     {fileToConvert && (
                         <button
@@ -237,9 +237,11 @@ const ConversionForm = ({
                     )}
                 </div>
                 <Divider className={styles.divider} orientation="right" />
-                <Button ghost onClick={cancelConversion}>Cancel</Button>
+                <Button className="secondary-button" onClick={cancelConversion}>
+                    Cancel
+                </Button>
                 <Button
-                    type="primary"
+                    className="primary-button"
                     disabled={!fileToConvert || !engineSelected}
                     onClick={sendFileToConvert}
                 >

--- a/src/containers/ConversionForm/style.css
+++ b/src/containers/ConversionForm/style.css
@@ -1,6 +1,6 @@
 .container {
     position: absolute;
-    background-color: var(--overlay-purple);
+    background-color: var(--light-theme-bg);
     height: calc(100vh - var(--header-height));
     width: 100%;
     z-index: 1000;
@@ -76,11 +76,11 @@
 }
 
 .remove-file-icon svg {
-    fill: var(--delete-file-icon-color);
+    fill: var(--cancel-icon-color);
 }
 
 .divider {
-    background-color: var(--light-theme-divider-bg);
+    background-color: var(--light-theme-divider);
 }
 
 .form-content button {
@@ -91,7 +91,7 @@
 
 .form-content span svg path {
     /* this makes the down arrow in the select box visible  */
-    color: var(--light-theme-btn-default-color);
+    color: var(--light-theme-btn-primary-border);
 }
 
 .container .loading-icon,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,9 +18,8 @@ import AppHeader from "./containers/AppHeader";
 const { Header } = Layout;
 
 import "./style.css";
-import { setIsPlaying, setStatus } from "./state/viewer/actions";
+import { setIsPlaying } from "./state/viewer/actions";
 import { clearSimulariumFile } from "./state/trajectory/actions";
-import { VIEWER_EMPTY } from "./state/viewer/constants";
 
 export const store = createReduxStore();
 interface LocationWithState extends Location {

--- a/src/state/trajectory/actions.ts
+++ b/src/state/trajectory/actions.ts
@@ -1,7 +1,5 @@
 import { SimulariumController } from "@aics/simularium-viewer";
 
-import { SimulariumController } from "@aics/simularium-viewer";
-
 import {
     RECEIVE_TRAJECTORY,
     REQUEST_TRAJECTORY,

--- a/src/state/trajectory/constants.ts
+++ b/src/state/trajectory/constants.ts
@@ -15,8 +15,6 @@ export const RECEIVE_SIMULARIUM_FILE = makeTrajectoryConstant(
 );
 export const LOAD_LOCAL_FILE_IN_VIEWER =
     makeTrajectoryConstant("load-local-file");
-export const LOAD_LOCAL_FILE_IN_VIEWER =
-    makeTrajectoryConstant("load-local-file");
 export const LOAD_NETWORKED_FILE_IN_VIEWER = makeTrajectoryConstant(
     "load-networked-file"
 );

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -20,6 +20,7 @@
     --grayish-brown: #4a4a4a;
     --warm-gray: #979797;
     --charcoal-gray: #3b3649;
+    --slate-gray: #4b4b4b;
     --light-purple: #e7e4f2;
     --light-purple-two: #d7c8ff;
     --baby-purple: #b59ff6;
@@ -56,8 +57,8 @@
     --dark-theme-primary-button-hover-bg: var(--light-purple-two);
     --dark-theme-primary-button-hover-border: var(--light-purple-two);
     --dark-theme-primary-button-hover-color: var(--dark-two);
-    --dark-theme-primary-button-disabled-bg: var(--dark-three);
-    --dark-theme-primary-button-disabled-border: var(--dark-three);
+    --dark-theme-primary-button-disabled-bg: var(--slate-gray);
+    --dark-theme-primary-button-disabled-border: var(--slate-gray);
     --dark-theme-primary-button-disabled-color: var(--text-gray);
     /* dark theme secondary buttons */
     --dark-theme-secondary-button-bg: transparent;
@@ -96,6 +97,7 @@
     /* Light theme */
     /* general */
     --light-theme-bg: var(--light-purple);
+    --light-theme-color: var(--dark);
     --light-theme-white-bg: var(--pure-white);
     --light-theme-gray-bg: var(--white-four);
     --light-theme-faint-text: var(--white-two);
@@ -103,6 +105,7 @@
     --light-theme-heading2-color: var(--grayish-brown);
     --light-theme-checkbox-color: var(--dark-three);
     --light-theme-blue-text: var(--blue);
+    --light-theme-divider: var(--heather);
     /* modal colors */
     --light-theme-modal-bg: var(--light-theme-bg);
     --light-theme-modal-color: var(--dark);


### PR DESCRIPTION
Time estimate or Size
=======
_Medium/Small: many changes are obvious, there's essentially no logic_

Problem
=======
I merged main into 346 and now the styling is a bit whacked up, because there have been recent changes to color vars, custom modal props, etc. This deals with merge issues and refactors conversion branch to work with current styling approaches.

_Note: there is a bug/issue where the converted file is not recognized upon load and so it does not display a title and the Download and Share buttons remain disabled despite a file being loaded. The changes for that bug are in process pending discussion of changes to Octopus and TrajectoryInfo typing. I think its acceptable to proceed with this PR (and merge to main) with that resolution pending, as this will not go to production until Octopus is live._

Solution
========
This PR fixes the handful of erroneous merge artifacts, and brings the `ConversionForm`, `ConversionOverlay`, and various conversion modals into alignment with the recent changes to `CustomModal`, color variable naming, etc. etc.

Most of the changes to the modals are just using the new props for `CustomModal` and a couple style tweaks.

To review styling on on modals and processing overlay, outside of just looking at screenshots I suggest just pasting the following code blocks into the `ConversionForm` render function outside of the usual conditional rendering:
```
             <ConversionServerErrorModal
                    closeModal={toggleServerCheckModal}
                />
                
                                <ConversionFileErrorModal
                    closeModal={toggleFileTypeModal}
                    engineType={conversionProcessingData.engineType}
                />
                
                                <ConversionProcessingOverlay
                    fileName={conversionProcessingData.fileName}
                    cancelProcessing={cancelProcessing}
                />
```
You can upload an invalid file type to test the file type error, but triggering the server error and getting it to hang out on the processing overlay is a little more fussy.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Convert a file and confirm everything still works after merging main.
2. Check out the conversion form, overlay and modals and see that they look like the current light-theme guidance.

Screenshots (optional):
<img width="572" alt="Screenshot 2024-04-03 at 5 05 18 PM" src="https://github.com/simularium/simularium-website/assets/24981838/deccd108-732e-4f3f-86ad-9a1cccaab4a5">
<img width="1418" alt="Screenshot 2024-04-03 at 4 53 59 PM" src="https://github.com/simularium/simularium-website/assets/24981838/45db0608-fab5-4739-ab5f-44703dd10332">

-----------------------
<img width="578" alt="Screenshot 2024-04-03 at 5 05 44 PM" src="https://github.com/simularium/simularium-website/assets/24981838/0b7708d1-6974-4b7c-833f-293270779b0b">


<img width="983" alt="Screenshot 2024-04-03 at 5 05 58 PM" src="https://github.com/simularium/simularium-website/assets/24981838/2e978b82-dabf-4050-834f-5a135799e554">
