### PR TITLE
play button shouldn't be disabled at the last frame

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -132,7 +132,7 @@ const PlayBackControls = ({
                     clickHandler={
                         isPlaying ? pauseHandler : () => playHandler()
                     }
-                    disabled={isStepForwardDisabled || loading || isEmpty}
+                    disabled={loading || isEmpty}
                     loading={loading}
                 />
                 <ViewportButton


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
Play button is disabled when a playing trajectory hits the last frame and pauses
[Link to story or ticket](https://github.com/simularium/simularium-website/issues/503)

