### PR TITLE
check if children have different colors and expand by default if so

### DIFF
--- a/src/components/AgentTree/index.tsx
+++ b/src/components/AgentTree/index.tsx
@@ -257,9 +257,7 @@ class AgentTree extends React.Component<AgentTreeProps> {
                 <TreeNode headerContent={this.renderCheckAllButton()} />
                 {treeData.map((nodeData) => {
                     const childrenHaveDifferentColors = nodeData.children.some(
-                        (child) => {
-                            return child.color !== nodeData.children[0].color;
-                        }
+                        (child, _, arr) => child.color !== arr[0].color
                     );
                     return (
                         <TreeNode

--- a/src/components/AgentTree/index.tsx
+++ b/src/components/AgentTree/index.tsx
@@ -256,6 +256,11 @@ class AgentTree extends React.Component<AgentTreeProps> {
             <div className={styles.container}>
                 <TreeNode headerContent={this.renderCheckAllButton()} />
                 {treeData.map((nodeData) => {
+                    const childrenHaveDifferentColors = nodeData.children.some(
+                        (child) => {
+                            return child.color !== nodeData.children[0].color;
+                        }
+                    );
                     return (
                         <TreeNode
                             headerContent={
@@ -289,7 +294,7 @@ class AgentTree extends React.Component<AgentTreeProps> {
                                     </Text>
                                 </>
                             }
-                            expandByDefault={!nodeData.color}
+                            expandByDefault={childrenHaveDifferentColors}
                             key={nodeData.key}
                         >
                             {nodeData.children.length > 0 && (


### PR DESCRIPTION
Time estimate or Size
=======
_x-small_

Problem
=======
Closes #505 

Solution
========
Check if agent children have different colors and pass value to existing `expandByDefault` prop.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open [this trajectory](https://simularium.allencell.org/viewer?trajUrl=https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/binding-affinity_antibodies.simularium) with this branch and see if second agent is expanded and first is not.

Screenshots (optional):
-----------------------
![Screenshot 2024-04-30 at 10 32 11 AM](https://github.com/simularium/simularium-website/assets/24981838/24e8b133-67f5-4e43-83cd-b0b079fa8006)
