### PR TITLE
Fix/send cancel autoconversion msg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.11.0",
             "license": "ISC",
             "dependencies": {
-                "@aics/simularium-viewer": "^3.7.4",
+                "@aics/simularium-viewer": "^3.8.0",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "antd": "^4.23.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.11.0",
             "license": "ISC",
             "dependencies": {
-                "@aics/simularium-viewer": "^3.8.0",
+                "@aics/simularium-viewer": "^3.7.4",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "antd": "^4.23.6",

--- a/src/containers/ConversionForm/index.tsx
+++ b/src/containers/ConversionForm/index.tsx
@@ -116,7 +116,6 @@ const ConversionForm = ({
 
     const cancelProcessing = () => {
         setIsProcessing(false);
-        setConversionStatus({ status: ConversionStatus.NoServer });
         // todo - keep old trajectory and timestamp when cancelling conversion request
         clearSimulariumFile({ newFile: false });
         cancelAutoconversion();

--- a/src/containers/ConversionForm/index.tsx
+++ b/src/containers/ConversionForm/index.tsx
@@ -17,6 +17,7 @@ import {
     ReceiveFileToConvertAction,
     SetConversionEngineAction,
     SetConversionStatusAction,
+    CancelConversionAction,
 } from "../../state/trajectory/types";
 import { SetErrorAction } from "../../state/viewer/types";
 import {
@@ -44,6 +45,7 @@ interface ConversionProps {
     conversionStatus: ConversionStatus;
     setConversionStatus: ActionCreator<SetConversionStatusAction>;
     clearSimulariumFile: ActionCreator<ClearSimFileDataAction>;
+    cancelAutoconversion: ActionCreator<CancelConversionAction>;
 }
 
 const validFileExtensions: ExtensionMap = {
@@ -74,6 +76,7 @@ const ConversionForm = ({
     convertFile,
     setConversionStatus,
     clearSimulariumFile,
+    cancelAutoconversion,
 }: ConversionProps): JSX.Element => {
     const [fileToConvert, setFileToConvert] = useState<UploadFile | null>();
     const [isProcessing, setIsProcessing] = useState<boolean>(false);
@@ -116,6 +119,7 @@ const ConversionForm = ({
         setConversionStatus({ status: ConversionStatus.NoServer });
         // todo - keep old trajectory and timestamp when cancelling conversion request
         clearSimulariumFile({ newFile: false });
+        cancelAutoconversion();
     };
 
     const cancelConversion = () => {
@@ -277,6 +281,7 @@ const dispatchToPropsMap = {
     convertFile: trajectoryStateBranch.actions.convertFile,
     setConversionStatus: trajectoryStateBranch.actions.setConversionStatus,
     clearSimulariumFile: trajectoryStateBranch.actions.clearSimulariumFile,
+    cancelAutoconversion: trajectoryStateBranch.actions.cancelAutoconversion,
 };
 
 export default connect(mapStateToProps, dispatchToPropsMap)(ConversionForm);

--- a/src/containers/ConversionForm/index.tsx
+++ b/src/containers/ConversionForm/index.tsx
@@ -117,8 +117,8 @@ const ConversionForm = ({
     const cancelProcessing = () => {
         setIsProcessing(false);
         // todo - keep old trajectory and timestamp when cancelling conversion request
-        clearSimulariumFile({ newFile: false });
         cancelAutoconversion();
+        clearSimulariumFile({ newFile: false });
     };
 
     const cancelConversion = () => {

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -20,6 +20,7 @@ import {
     RequestLocalFileAction,
     RequestNetworkFileAction,
     SetUrlParamsAction,
+    CancelConversionAction,
 } from "../../state/trajectory/types";
 import { ConversionProcessingData } from "../../state/trajectory/conversion-data-types";
 import {
@@ -78,6 +79,7 @@ interface AppProps {
     conversionStatus: ConversionStatus;
     initializeConversion: ActionCreator<InitializeConversionAction>;
     setUrlParams: ActionCreator<SetUrlParamsAction>;
+    cancelAutoconversion: ActionCreator<CancelConversionAction>;
 }
 
 interface AppState {
@@ -309,6 +311,7 @@ const dispatchToPropsMap = {
     setViewerStatus: viewerStateBranch.actions.setStatus,
     setError: viewerStateBranch.actions.setError,
     initializeConversion: trajectoryStateBranch.actions.initializeConversion,
+    cancelAutoconversion: trajectoryStateBranch.actions.cancelAutoconversion,
 };
 
 export default connect(mapStateToProps, dispatchToPropsMap)(App);

--- a/src/state/trajectory/actions.ts
+++ b/src/state/trajectory/actions.ts
@@ -18,6 +18,7 @@ import {
     SET_CONVERSION_STATUS,
     CONVERT_FILE,
     RECEIVE_CONVERTED_FILE,
+    CANCEL_CONVERSION,
 } from "./constants";
 import { AvailableEngines } from "./conversion-data-types";
 import {
@@ -38,6 +39,7 @@ import {
     SetConversionStatusAction,
     ConvertFileAction,
     ConversionStatus,
+    CancelConversionAction,
 } from "./types";
 
 export function receiveTrajectory(
@@ -186,5 +188,11 @@ export function receiveConvertedFile(payload: NetworkedSimFile): ReceiveAction {
     return {
         payload,
         type: RECEIVE_CONVERTED_FILE,
+    };
+}
+
+export function cancelAutoconversion(): CancelConversionAction {
+    return {
+        type: CANCEL_CONVERSION,
     };
 }

--- a/src/state/trajectory/constants.ts
+++ b/src/state/trajectory/constants.ts
@@ -37,5 +37,6 @@ export const RECEIVE_FILE_TO_CONVERT = makeTrajectoryConstant(
 export const CONVERT_FILE = makeTrajectoryConstant("convert-file");
 export const RECEIVE_CONVERTED_FILE =
     makeTrajectoryConstant("receive-converted");
+export const CANCEL_CONVERSION = makeTrajectoryConstant("cancel-conversion");
 
 export const SET_CONVERSION_STATUS = makeTrajectoryConstant("set-status");

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -622,11 +622,16 @@ const receiveConvertedFileLogic = createLogic({
 });
 
 const cancelConversionLogic = createLogic({
-    process(deps: ReduxLogicDeps) {
+    process(deps: ReduxLogicDeps, dispatch) {
         const { getState } = deps;
         const currentState = getState();
         const simulariumController = getSimulariumController(currentState);
         simulariumController.cancelConversion();
+        dispatch(
+            setConversionStatus({
+                status: CONVERSION_NO_SERVER,
+            })
+        );
     },
     type: CANCEL_CONVERSION,
 });

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -629,7 +629,7 @@ const cancelConversionLogic = createLogic({
         simulariumController.cancelConversion();
         dispatch(
             setConversionStatus({
-                status: CONVERSION_NO_SERVER,
+                status: ConversionStatus.NoServer,
             })
         );
     },

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -59,6 +59,7 @@ import {
     SET_CONVERSION_TEMPLATE,
     CONVERT_FILE,
     RECEIVE_CONVERTED_FILE,
+    CANCEL_CONVERSION,
 } from "./constants";
 import {
     ReceiveAction,
@@ -620,6 +621,16 @@ const receiveConvertedFileLogic = createLogic({
     type: RECEIVE_CONVERTED_FILE,
 });
 
+const cancelConversionLogic = createLogic({
+    process(deps: ReduxLogicDeps) {
+        const { getState } = deps;
+        const currentState = getState();
+        const simulariumController = getSimulariumController(currentState);
+        simulariumController.cancelConversion();
+    },
+    type: CANCEL_CONVERSION,
+});
+
 export default [
     requestPlotDataLogic,
     loadLocalFile,
@@ -631,4 +642,5 @@ export default [
     initializeFileConversionLogic,
     convertFileLogic,
     receiveConvertedFileLogic,
+    cancelConversionLogic,
 ];

--- a/src/state/trajectory/types.ts
+++ b/src/state/trajectory/types.ts
@@ -81,6 +81,10 @@ export interface SetConversionStatusAction {
     type: string;
 }
 
+export interface CancelConversionAction {
+    type: string;
+}
+
 export interface LocalSimFile {
     name: string;
     data: ISimulariumFile;


### PR DESCRIPTION
Time estimate or Size
=======
small

Problem
=======
Now that we have cancel autoconversion functionality in Octopus, and a cancel autoconversion message that the viewer can send to trigger that, the website should trigger this when a user selects to cancel a conversion request that's processing

[Related to this ticket](https://github.com/simularium/octopus/issues/87)

Solution
========
Added call to `SimulariumController.cancelConversion()` when user has cancelled their conversion request.

Did this using redux (for my very first time) since we will likely need to add more functionality to cancelConversionLogic in the future to properly restore the previous state of the viewer when a user has cancelled a conversion request.