### PR TITLE
DRAFT: revert octopus changes and point to simularium-engine, if octopus launch fails

### DIFF
--- a/src/components/LoadFileMenu/index.tsx
+++ b/src/components/LoadFileMenu/index.tsx
@@ -99,17 +99,6 @@ const LoadFileMenu = ({
                 </Button>
             ),
         },
-        {
-            key: "file-convert",
-            label: (
-                <Link
-                    onClick={openConversionForm}
-                    to={{ pathname: VIEWER_PATHNAME }}
-                >
-                    Import other file type
-                </Link>
-            ),
-        },
     ];
 
     const isDisabled =

--- a/src/containers/AppHeader/index.tsx
+++ b/src/containers/AppHeader/index.tsx
@@ -104,11 +104,6 @@ const AppHeader: React.FC<AppHeaderProps> = ({
                     setConversionStatus={setConversionStatus}
                 />
                 <HelpMenu key="help" />
-                <DownloadTrajectoryMenu
-                    isBuffering={isBuffering}
-                    simulariumFile={simulariumFile}
-                    isNetworkedFile={isNetworkedFile}
-                />
                 <ShareTrajectoryButton
                     simulariumFile={simulariumFile}
                     isBuffering={isBuffering}

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -78,9 +78,7 @@ import {
 
 const netConnectionSettings: NetConnectionParams = {
     serverIp: process.env.BACKEND_SERVER_IP,
-    serverPort: 443,
-    useOctopus: true,
-    secureConnection: true,
+    serverPort: 9002,
 };
 
 const resetSimulariumFileState = createLogic({

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -75,18 +75,18 @@ const BUNDLE_ANALYZER = [
 const PLUGINS_BY_ENV = {
     [Env.PRODUCTION]: [
         new webpack.EnvironmentPlugin({
-            BACKEND_SERVER_IP: `production-simularium-ecs.allencell.org`,
+            BACKEND_SERVER_IP: `production-node1-agentviz-backend.cellexplore.net`,
         }),
     ],
     [Env.STAGE]: [
         new webpack.EnvironmentPlugin({
-            BACKEND_SERVER_IP: `staging-simularium-ecs.allencell.org`,
+            BACKEND_SERVER_IP: `staging-node1-agentviz-backend.cellexplore.net`,
         }),
     ],
     [Env.DEVELOPMENT]: [
         new webpack.EnvironmentPlugin({
             // FIXME: make a dev server
-            BACKEND_SERVER_IP: `staging-simularium-ecs.allencell.org`,
+            BACKEND_SERVER_IP: `staging-node1-agentviz-backend.cellexplore.net`,
         }),
     ],
 };


### PR DESCRIPTION
Hopefully we'll never merge this!

This will point us back at simularium-engine if our transition to octopus fails