### PR TITLE
Bug Fix: Plots not showing up for example trajectories

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,6 +15,8 @@ export const URL_PARAM_BASE_TYPES = "base_types.json";
 export const URL_PARAM_CUSTOM_TYPES = "custom-types";
 // URLs
 export const BASE_API_URL = `/api/${API_VERSION}`;
+export const DATA_BUCKET_URL =
+    "https://aics-simularium-data.s3.us-east-2.amazonaws.com";
 export const DOWNLOAD_URL = `https://${process.env.BACKEND_SERVER_IP}:443/download`;
 export const FORUM_URL =
     "https://forum.allencell.org/c/software-code/simularium/";

--- a/src/state/configure-store.ts
+++ b/src/state/configure-store.ts
@@ -5,7 +5,6 @@ import { createLogicMiddleware } from "redux-logic";
 import {
     BASE_API_URL,
     DATA_BUCKET_URL,
-    DOWNLOAD_URL,
     UI_TEMPLATE_DOWNLOAD_URL_ROOT,
     UI_TEMPLATE_URL_ROOT,
     URL_PARAM_BASE_TYPES,

--- a/src/state/configure-store.ts
+++ b/src/state/configure-store.ts
@@ -4,6 +4,7 @@ import { createLogicMiddleware } from "redux-logic";
 
 import {
     BASE_API_URL,
+    DATA_BUCKET_URL,
     DOWNLOAD_URL,
     UI_TEMPLATE_DOWNLOAD_URL_ROOT,
     UI_TEMPLATE_URL_ROOT,
@@ -37,7 +38,7 @@ const logics = [
 
 const reduxLogicDependencies = {
     baseApiUrl: BASE_API_URL,
-    plotDataUrl: DOWNLOAD_URL,
+    plotDataUrl: DATA_BUCKET_URL,
     httpClient: axios,
     uiTemplateUrlRoot: UI_TEMPLATE_URL_ROOT,
     uiTemplateDownloadUrlRoot: UI_TEMPLATE_DOWNLOAD_URL_ROOT,


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
While I was looking for potential bugs in simularium after octopus launched, I realized that no plots were showing up. I looked  at the console, and realized we were getting 404 errors because we were requesting the plot json objects from the wrong spot.

Solution
========
I re-added `DATA_BUCKET_URL`, which had been removed previously because in a different use case, this URL was no longer needed. However, we still need this for getting the plots.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

## Side question
Why are our plots saved here? Can't they just be part of the .simularium file?


## Before (with bug)
<img width="1511" alt="Screen Shot 2024-05-28 at 3 59 12 PM" src="https://github.com/simularium/simularium-website/assets/111383930/24b19d68-fa32-4be5-8466-98151a2af891">

## After
<img width="1509" alt="Screen Shot 2024-05-28 at 3 58 09 PM" src="https://github.com/simularium/simularium-website/assets/111383930/0b6ca8f7-e3c1-49a1-a7c6-a0505ad33ced">

