### PR TITLE
update viewer version to 3.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.12.1",
             "license": "ISC",
             "dependencies": {
-                "@aics/simularium-viewer": "^3.8.0",
+                "@aics/simularium-viewer": "^3.8.1",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "antd": "^4.23.6",
@@ -116,9 +116,9 @@
             "dev": true
         },
         "node_modules/@aics/simularium-viewer": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.0.tgz",
-            "integrity": "sha512-4CCIIQZfqjOtwzn9qEiwSsBoi+XbYrgFVw8NlHblTWVb4ipZ0j+Ya4vOQQKa7jjj3wBXjMZzOaavZgsLeh/1kQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.1.tgz",
+            "integrity": "sha512-zL9CdMUeL3bZpBofpeSWKoH/hWLht/D5FzesnF6Y+Sb4+Ko6UDzu9Zx54ytgJZL6BjcUEFxVJ21X/2nFH8BX0w==",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.23.6",
                 "@babel/runtime": "^7.23.6",
@@ -24148,9 +24148,9 @@
             "dev": true
         },
         "@aics/simularium-viewer": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.0.tgz",
-            "integrity": "sha512-4CCIIQZfqjOtwzn9qEiwSsBoi+XbYrgFVw8NlHblTWVb4ipZ0j+Ya4vOQQKa7jjj3wBXjMZzOaavZgsLeh/1kQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.1.tgz",
+            "integrity": "sha512-zL9CdMUeL3bZpBofpeSWKoH/hWLht/D5FzesnF6Y+Sb4+Ko6UDzu9Zx54ytgJZL6BjcUEFxVJ21X/2nFH8BX0w==",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.23.6",
                 "@babel/runtime": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "webpack-dev-server": "^4.10.1"
     },
     "dependencies": {
-        "@aics/simularium-viewer": "^3.8.0",
+        "@aics/simularium-viewer": "^3.8.1",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "antd": "^4.23.6",


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
Updating the viewer version in the website code base so we can get [this viewer change](https://github.com/simularium/simularium-viewer/pull/390) into staging and I release [this octopus change](https://github.com/simularium/octopus/pull/97) into staging at the same time.  

Just trying to do this sooner rather than later since these two need to reach staging (and later prod) at the same time, or else the environment will break.