### PR TITLE
Fix/default octopus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Simularium repositories
 This repository is part of the Simularium project ([simularium.allencell.org](https://simularium.allencell.org)), which includes repositories:
 - [simulariumIO](https://github.com/simularium/simulariumio) - Python package that converts simulation outputs to the format consumed by the Simularium viewer website
-- [simularium-engine](https://github.com/simularium/simularium-engine) - C++ backend application that interfaces with biological simulation engines and serves simulation data to the front end website
+- [octopus](https://github.com/simularium/octopus) - Python backend application that interfaces with biological simulation engines and serves simulation data to the front end website
 - [simularium-viewer](https://github.com/simularium/simularium-viewer) - NPM package to view Simularium trajectories in 3D
 - [simularium-website](https://github.com/simularium/simularium-website) - Front end website for the Simularium project, includes the Simularium viewer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.12.1",
             "license": "ISC",
             "dependencies": {
-                "@aics/simularium-viewer": "^3.8.1",
+                "@aics/simularium-viewer": "^3.8.2",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "antd": "^4.23.6",
@@ -116,9 +116,9 @@
             "dev": true
         },
         "node_modules/@aics/simularium-viewer": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.1.tgz",
-            "integrity": "sha512-zL9CdMUeL3bZpBofpeSWKoH/hWLht/D5FzesnF6Y+Sb4+Ko6UDzu9Zx54ytgJZL6BjcUEFxVJ21X/2nFH8BX0w==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.2.tgz",
+            "integrity": "sha512-7DAOAr/zYwA8lSwWwedOZFSQDZpKditrqMSK99d3vERQ28IsZug8P2PCOq1xNA2jku65G3KtMcAGZq/QtSpApg==",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.23.6",
                 "@babel/runtime": "^7.23.6",
@@ -24148,9 +24148,9 @@
             "dev": true
         },
         "@aics/simularium-viewer": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.1.tgz",
-            "integrity": "sha512-zL9CdMUeL3bZpBofpeSWKoH/hWLht/D5FzesnF6Y+Sb4+Ko6UDzu9Zx54ytgJZL6BjcUEFxVJ21X/2nFH8BX0w==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.2.tgz",
+            "integrity": "sha512-7DAOAr/zYwA8lSwWwedOZFSQDZpKditrqMSK99d3vERQ28IsZug8P2PCOq1xNA2jku65G3KtMcAGZq/QtSpApg==",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.23.6",
                 "@babel/runtime": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "webpack-dev-server": "^4.10.1"
     },
     "dependencies": {
-        "@aics/simularium-viewer": "^3.8.1",
+        "@aics/simularium-viewer": "^3.8.2",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "antd": "^4.23.6",

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -79,8 +79,6 @@ import {
 const netConnectionSettings: NetConnectionParams = {
     serverIp: process.env.BACKEND_SERVER_IP,
     serverPort: 443,
-    useOctopus: true,
-    secureConnection: true,
 };
 
 const resetSimulariumFileState = createLogic({


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
Last piece of [this ticket](https://github.com/simularium/simularium-viewer/issues/389)

Solution
========
Update the viewer version, and remove params in net connection settings that don't exist any longer now that we are always pointing to Octopus.

This pulls in the viewer changes from [this PR](https://github.com/simularium/simularium-viewer/pull/391)