### PR TITLE
remove title from embed view

### DIFF
--- a/src/components/EmbedOverlay/index.tsx
+++ b/src/components/EmbedOverlay/index.tsx
@@ -2,18 +2,14 @@ import React from "react";
 
 import styles from "./style.css";
 
-interface ViewerOverlayTargetProps {
-    title: string;
-}
+// interface ViewerOverlayTargetProps {
+// placeholder for anything that
+// we want to have on the viewer
+// for the embed view
+// }
 
-const EmbedOverlay = ({
-    title,
-}: ViewerOverlayTargetProps): JSX.Element | null => {
-    return (
-        <div className={styles.container}>
-            <h4>{title}</h4>
-        </div>
-    );
+const EmbedOverlay = ({}): JSX.Element | null => {
+    return <div className={styles.container}></div>;
 };
 
 export default EmbedOverlay;

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -209,7 +209,6 @@ class App extends React.Component<AppProps, AppState> {
 
     public renderOverlay(isEmbedded: boolean) {
         const {
-            simulariumFile,
             resetDragOverViewer,
             changeToLocalSimulariumFile,
             viewerStatus,
@@ -219,7 +218,7 @@ class App extends React.Component<AppProps, AppState> {
             setError,
         } = this.props;
         if (isEmbedded) {
-            return <EmbedOverlay title={simulariumFile.name} />;
+            return <EmbedOverlay />;
         } else {
             return (
                 <ViewerOverlayTarget


### PR DESCRIPTION
Time estimate or Size
=======
 xsmall

Problem
=======
What is the problem this work solves, including
closes #538 

Solution
========
removed the title from the overlay 
I did leave a props object there, I can delete it, but I think we are going to have some overlay buttons in the embed view 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. npm start
2. go to http://localhost:9001/embed?trajFileName=medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.675.simularium
3. no title should be showing 

Screenshots (optional):
-----------------------
<img width="1425" alt="Screenshot 2024-06-25 at 11 24 21 AM" src="https://github.com/simularium/simularium-website/assets/5170636/a9ab4b22-6684-4085-a627-adaaabe47aac">
