### PR TITLE
both sidebars get full height on embed

### DIFF
--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -12,8 +12,8 @@ import styles from "./style.css";
 interface SiderProps {
     type: string;
     onCollapse: (open: boolean) => void;
+    isEmbedded: boolean;
     children?: React.ReactNode;
-    isEmbedded?: boolean;
 }
 
 interface SiderState {

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -271,7 +271,11 @@ class App extends React.Component<AppProps, AppState> {
                                 />
                             )}
                         </Content>
-                        <SideBar onCollapse={this.onPanelCollapse} type="right">
+                        <SideBar
+                            onCollapse={this.onPanelCollapse}
+                            isEmbedded={isEmbedded}
+                            type="right"
+                        >
                             <ResultsPanel />
                         </SideBar>
                     </Layout>


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
there was a gap of whitespace on the bottom of the plots in the embed view 

Solution
========
made sure both sidebars got the embed class

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Screenshots (optional):
-----------------------
<img width="1033" alt="Screenshot 2024-06-25 at 11 33 14 AM" src="https://github.com/simularium/simularium-website/assets/5170636/00d1c401-9ac0-4140-8792-dd164cb62102">

what it looked like before:
<img width="534" alt="Screenshot 2024-06-25 at 11 33 32 AM" src="https://github.com/simularium/simularium-website/assets/5170636/5f531dfa-f83b-41a0-9302-b3f78c32b427">

