### PR TITLE
Retain previous trajectory state when cancelling autoconversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.12.1",
             "license": "ISC",
             "dependencies": {
-                "@aics/simularium-viewer": "^3.8.2",
+                "@aics/simularium-viewer": "^3.8.3",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "antd": "^4.23.6",
@@ -116,9 +116,9 @@
             "dev": true
         },
         "node_modules/@aics/simularium-viewer": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.2.tgz",
-            "integrity": "sha512-7DAOAr/zYwA8lSwWwedOZFSQDZpKditrqMSK99d3vERQ28IsZug8P2PCOq1xNA2jku65G3KtMcAGZq/QtSpApg==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.3.tgz",
+            "integrity": "sha512-XdcjZRfPc8zH9ZXmopMZlg0UqYqJOs23zPCypcYzjH4n7QbciMvX8CzwlEd0ZXXeJJwR5a1cADN/LTgoksxOBQ==",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.23.6",
                 "@babel/runtime": "^7.23.6",
@@ -143,9 +143,9 @@
             }
         },
         "node_modules/@aics/simularium-viewer/node_modules/@babel/runtime": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-            "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+            "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -258,11 +258,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-            "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dependencies": {
-                "@babel/highlight": "^7.18.6"
+                "@babel/highlight": "^7.24.7",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -306,12 +307,13 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
-            "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
             "dependencies": {
-                "@babel/types": "^7.20.5",
-                "@jridgewell/gen-mapping": "^0.3.2",
+                "@babel/types": "^7.24.7",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -319,13 +321,13 @@
             }
         },
         "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -439,9 +441,12 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -459,23 +464,23 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-            "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
             "dependencies": {
-                "@babel/template": "^7.18.10",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-            "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -494,11 +499,12 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
-            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "dependencies": {
-                "@babel/types": "^7.24.0"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -535,9 +541,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
-            "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -600,28 +606,28 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-            "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -663,22 +669,23 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-            "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.18.6",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "chalk": "^2.4.2",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-            "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1678,12 +1685,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.3.tgz",
-            "integrity": "sha512-J0BuRPNlNqlMTRJ72eVptpt9VcInbxO6iP3jaxr+1NPhC0UkKL+6oeX6VXMEYdADnuqmMmsBspt4d5w8Y/TCbQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
+            "integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.3",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
                 "babel-plugin-polyfill-corejs3": "^0.10.1",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
@@ -2025,32 +2032,32 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dependencies": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
-            "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
             "dependencies": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.20.5",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-hoist-variables": "^7.18.6",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.20.5",
-                "@babel/types": "^7.20.5",
-                "debug": "^4.1.0",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-hoist-variables": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -2058,12 +2065,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -3324,9 +3331,9 @@
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -3361,12 +3368,12 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@leichtgewicht/ip-codec": {
@@ -24148,9 +24155,9 @@
             "dev": true
         },
         "@aics/simularium-viewer": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.2.tgz",
-            "integrity": "sha512-7DAOAr/zYwA8lSwWwedOZFSQDZpKditrqMSK99d3vERQ28IsZug8P2PCOq1xNA2jku65G3KtMcAGZq/QtSpApg==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.3.tgz",
+            "integrity": "sha512-XdcjZRfPc8zH9ZXmopMZlg0UqYqJOs23zPCypcYzjH4n7QbciMvX8CzwlEd0ZXXeJJwR5a1cADN/LTgoksxOBQ==",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.23.6",
                 "@babel/runtime": "^7.23.6",
@@ -24171,9 +24178,9 @@
             },
             "dependencies": {
                 "@babel/runtime": {
-                    "version": "7.24.5",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-                    "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+                    "version": "7.24.7",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+                    "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
                     "requires": {
                         "regenerator-runtime": "^0.14.0"
                     }
@@ -24262,11 +24269,12 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-            "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "requires": {
-                "@babel/highlight": "^7.18.6"
+                "@babel/highlight": "^7.24.7",
+                "picocolors": "^1.0.0"
             }
         },
         "@babel/compat-data": {
@@ -24297,23 +24305,24 @@
             }
         },
         "@babel/generator": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
-            "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
             "requires": {
-                "@babel/types": "^7.20.5",
-                "@jridgewell/gen-mapping": "^0.3.2",
+                "@babel/types": "^7.24.7",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "dependencies": {
                 "@jridgewell/gen-mapping": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-                    "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+                    "version": "0.3.5",
+                    "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+                    "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
                     "requires": {
-                        "@jridgewell/set-array": "^1.0.1",
+                        "@jridgewell/set-array": "^1.2.1",
                         "@jridgewell/sourcemap-codec": "^1.4.10",
-                        "@jridgewell/trace-mapping": "^0.3.9"
+                        "@jridgewell/trace-mapping": "^0.3.24"
                     }
                 }
             }
@@ -24404,9 +24413,12 @@
             }
         },
         "@babel/helper-environment-visitor": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+            "requires": {
+                "@babel/types": "^7.24.7"
+            }
         },
         "@babel/helper-explode-assignable-expression": {
             "version": "7.18.6",
@@ -24418,20 +24430,20 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-            "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
             "requires": {
-                "@babel/template": "^7.18.10",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-            "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
             "requires": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.24.7"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -24444,11 +24456,12 @@
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
-            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "requires": {
-                "@babel/types": "^7.24.0"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             }
         },
         "@babel/helper-module-transforms": {
@@ -24476,9 +24489,9 @@
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
-            "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ=="
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg=="
         },
         "@babel/helper-remap-async-to-generator": {
             "version": "7.18.9",
@@ -24523,22 +24536,22 @@
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-            "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "requires": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.24.7"
             }
         },
         "@babel/helper-string-parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ=="
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg=="
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA=="
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w=="
         },
         "@babel/helper-validator-option": {
             "version": "7.23.5",
@@ -24568,19 +24581,20 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-            "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "requires": {
-                "@babel/helper-validator-identifier": "^7.18.6",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "chalk": "^2.4.2",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-            "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA=="
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw=="
         },
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
             "version": "7.18.6",
@@ -25223,12 +25237,12 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.3.tgz",
-            "integrity": "sha512-J0BuRPNlNqlMTRJ72eVptpt9VcInbxO6iP3jaxr+1NPhC0UkKL+6oeX6VXMEYdADnuqmMmsBspt4d5w8Y/TCbQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
+            "integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
             "requires": {
-                "@babel/helper-module-imports": "^7.24.3",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
                 "babel-plugin-polyfill-corejs3": "^0.10.1",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
@@ -25482,39 +25496,39 @@
             }
         },
         "@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "requires": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             }
         },
         "@babel/traverse": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
-            "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
             "requires": {
-                "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.20.5",
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
-                "@babel/helper-hoist-variables": "^7.18.6",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.20.5",
-                "@babel/types": "^7.20.5",
-                "debug": "^4.1.0",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-hoist-variables": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "requires": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -26386,9 +26400,9 @@
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
         },
         "@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
         },
         "@jridgewell/source-map": {
             "version": "0.3.2",
@@ -26419,12 +26433,12 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "requires": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "@leichtgewicht/ip-codec": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "webpack-dev-server": "^4.10.1"
     },
     "dependencies": {
-        "@aics/simularium-viewer": "^3.8.2",
+        "@aics/simularium-viewer": "^3.8.3",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "antd": "^4.23.6",

--- a/src/containers/ConversionForm/index.tsx
+++ b/src/containers/ConversionForm/index.tsx
@@ -116,9 +116,7 @@ const ConversionForm = ({
 
     const cancelProcessing = () => {
         setIsProcessing(false);
-        // todo - keep old trajectory and timestamp when cancelling conversion request
         cancelAutoconversion();
-        clearSimulariumFile({ newFile: false });
     };
 
     const cancelConversion = () => {

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -627,7 +627,7 @@ const cancelConversionLogic = createLogic({
         simulariumController.cancelConversion();
         dispatch(
             setConversionStatus({
-                status: ConversionStatus.NoServer,
+                status: ConversionStatus.Inactive,
             })
         );
     },


### PR DESCRIPTION
Time estimate or Size
=======
_tiny, less than 5 min_

Problem
=======
Closes #525 

Solution
========
This issue was caused by having multiple websocket connections open during conversion, something @ascibisz fixed a while back.

So we can just stop clearing out the old trajectory when cancelling conversion and it should work fine.
