### PR TITLE
fix advanced controls

### DIFF
--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -9,6 +9,7 @@ import SimulariumViewer, {
     TrajectoryFileInfo,
     TimeData,
 } from "@aics/simularium-viewer";
+import "@aics/simularium-viewer/style/style.css";
 import { AgentData } from "@aics/simularium-viewer/type-declarations/simularium/types";
 import { connect } from "react-redux";
 import { Modal } from "antd";


### PR DESCRIPTION
Time estimate or Size
=======
_xsmall_

Problem
=======
advance controls are not visible

Solution
========
Viewer stylesheet import was accidentally deleted in [this PR](https://github.com/simularium/simularium-website/pull/532).

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. ctrl-option-1 to view controls
