### PR TITLE
don't pass unneeded custom props to native elements

### DIFF
--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -28,7 +28,8 @@ const tooltipOffsets: TooltipOffsets = {
 
 const Checkbox = (props: CheckboxTypeProps): JSX.Element => {
     // removing props that are only needed at this level
-    const childProps = { ...props, checkboxType: null, checkboxLevel: null };
+    const { checkboxType, checkboxLevel: removedLevel, ...childProps } = props;
+
     const checkboxLevel = props.checkboxLevel ? props.checkboxLevel : "default";
 
     const [showTooltip, setShowTooltip] = useState(false);

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -27,8 +27,10 @@ const tooltipOffsets: TooltipOffsets = {
 };
 
 const Checkbox = (props: CheckboxTypeProps): JSX.Element => {
+    const childProps = { ...props };
     // removing props that are only needed at this level
-    const { checkboxType, checkboxLevel: removedLevel, ...childProps } = props;
+    delete childProps.checkboxType;
+    delete childProps.checkboxLevel;
 
     const checkboxLevel = props.checkboxLevel ? props.checkboxLevel : "default";
 


### PR DESCRIPTION
Time estimate or Size
=======
_tiny_

Problem
=======
We are passing custom props to the native checkbox and getting this warning in the console when running main:
```
Warning: React does not recognize the `checkboxLevel` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `checkboxlevel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Solution
========
Deleting props instead of destructuring to remove (first commit) because linter was mad about it.