### PR TITLE
Feature/color sessions prep

### DIFF
--- a/src/components/AgentTree/index.tsx
+++ b/src/components/AgentTree/index.tsx
@@ -6,7 +6,7 @@ import { map, filter, isEmpty } from "lodash";
 
 import {
     ChangeAgentsRenderingStateAction,
-    SetColorChangeAction,
+    ApplyUserColorSelectionAction,
     SetRecentColorsAction,
     SetVisibleAction,
     AgentRenderingCheckboxMap,
@@ -45,7 +45,7 @@ interface AgentTreeProps {
     payloadForSelectNone: AgentRenderingCheckboxMap;
     isSharedCheckboxIndeterminate: boolean;
     recentColors: string[];
-    setColorChange: ActionCreator<SetColorChangeAction>;
+    applyUserColorSelection: ActionCreator<ApplyUserColorSelectionAction>;
     setRecentColors: ActionCreator<SetRecentColorsAction>;
 }
 const CHECKBOX_SPAN_NO = 2;
@@ -214,7 +214,8 @@ class AgentTree extends React.Component<AgentTreeProps> {
     };
 
     renderParentColorPicker = (nodeData: AgentDisplayNode) => {
-        const { recentColors, setColorChange, setRecentColors } = this.props;
+        const { recentColors, applyUserColorSelection, setRecentColors } =
+            this.props;
         const childrenHaveDifferentColors = !nodeData.children.every(
             (el) =>
                 el.color.toLowerCase() ===
@@ -227,7 +228,7 @@ class AgentTree extends React.Component<AgentTreeProps> {
                 agentName={nodeData.title}
                 tags={this.getAgentTags(nodeData.title)}
                 recentColors={recentColors}
-                setColorChange={setColorChange}
+                applyUserColorSelection={applyUserColorSelection}
                 setRecentColors={setRecentColors}
             />
         );
@@ -237,14 +238,15 @@ class AgentTree extends React.Component<AgentTreeProps> {
         nodeData: AgentDisplayNode,
         value: CheckBoxWithColor
     ) => {
-        const { recentColors, setColorChange, setRecentColors } = this.props;
+        const { recentColors, applyUserColorSelection, setRecentColors } =
+            this.props;
         return (
             <ColorPicker
                 selectedColor={value.color || nodeData.color}
                 agentName={nodeData.title}
                 tags={[value.value as string]}
                 recentColors={recentColors}
-                setColorChange={setColorChange}
+                applyUserColorSelection={applyUserColorSelection}
                 setRecentColors={setRecentColors}
             />
         );

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -8,7 +8,7 @@ import { useDebounce } from "use-debounce";
 import { AGENT_COLORS } from "../../containers/ViewerPanel/constants";
 import { ColorChange } from "../../constants/interfaces";
 import {
-    SetColorChangeAction,
+    ApplyUserColorSelectionAction,
     SetRecentColorsAction,
 } from "../../state/selection/types";
 
@@ -20,7 +20,7 @@ interface ColorPickerProps {
     agentName: string;
     tags: string[];
     recentColors: string[];
-    setColorChange: ActionCreator<SetColorChangeAction>;
+    applyUserColorSelection: ActionCreator<ApplyUserColorSelectionAction>;
     setRecentColors: ActionCreator<SetRecentColorsAction>;
 }
 
@@ -28,7 +28,7 @@ const ColorPicker = ({
     agentName,
     tags,
     recentColors,
-    setColorChange,
+    applyUserColorSelection,
     setRecentColors,
     selectedColor: initialColor,
     childrenHaveDifferentColors,
@@ -53,7 +53,7 @@ const ColorPicker = ({
             agent: { name: agentName, tags: tags },
             color: newColor.toLowerCase(),
         };
-        setColorChange(colorChange);
+        applyUserColorSelection(colorChange);
     };
 
     useEffect(() => {

--- a/src/containers/ModelPanel/index.tsx
+++ b/src/containers/ModelPanel/index.tsx
@@ -2,7 +2,10 @@ import * as React from "react";
 import { ActionCreator } from "redux";
 import { connect } from "react-redux";
 
-import SideBarContents from "../../components/SideBarContents";
+import { State } from "../../state/types";
+import { ViewerStatus } from "../../state/viewer/types";
+import { getStatus } from "../../state/viewer/selectors";
+import { RequestNetworkFileAction } from "../../state/trajectory/types";
 import {
     requestTrajectory,
     changeToNetworkedFile,
@@ -11,35 +14,32 @@ import {
     getUiDisplayDataTree,
     getIsNetworkedFile,
 } from "../../state/trajectory/selectors";
-import { getStatus } from "../../state/viewer/selectors";
-import { State } from "../../state/types";
+import {
+    AgentRenderingCheckboxMap,
+    ChangeAgentsRenderingStateAction,
+    SetVisibleAction,
+    SetRecentColorsAction,
+    ApplyUserColorSelectionAction,
+} from "../../state/selection/types";
+import {
+    turnAgentsOnByDisplayKey,
+    highlightAgentsByDisplayKey,
+    setAgentsVisible,
+    setRecentColors,
+    applyUserColorSelection,
+} from "../../state/selection/actions";
 import {
     getAgentVisibilityMap,
     getAgentHighlightMap,
     getRecentColors,
     getSelectedAgentMetadata,
 } from "../../state/selection/selectors";
-import {
-    turnAgentsOnByDisplayKey,
-    highlightAgentsByDisplayKey,
-    setAgentsVisible,
-    setColorChange,
-    setRecentColors,
-} from "../../state/selection/actions";
-import {
-    ChangeAgentsRenderingStateAction,
-    SetColorChangeAction,
-    SetVisibleAction,
-    AgentRenderingCheckboxMap,
-    SetRecentColorsAction,
-} from "../../state/selection/types";
 import CheckBoxTree, { AgentDisplayNode } from "../../components/AgentTree";
-import { AgentMetadata } from "../../constants/interfaces";
 import NoTrajectoriesText from "../../components/NoTrajectoriesText";
-import { RequestNetworkFileAction } from "../../state/trajectory/types";
-import { ViewerStatus } from "../../state/viewer/types";
 import NetworkFileFailedText from "../../components/NoTrajectoriesText/NetworkFileFailedText";
 import NoTypeMappingText from "../../components/NoTrajectoriesText/NoTypeMappingText";
+import SideBarContents from "../../components/SideBarContents";
+import { AgentMetadata } from "../../constants/interfaces";
 import {
     getSelectAllVisibilityMap,
     getSelectNoneVisibilityMap,
@@ -62,7 +62,7 @@ interface ModelPanelProps {
     isNetworkedFile: boolean;
     changeToNetworkedFile: ActionCreator<RequestNetworkFileAction>;
     recentColors: string[];
-    setColorChange: ActionCreator<SetColorChangeAction>;
+    applyUserColorSelection: ActionCreator<ApplyUserColorSelectionAction>;
     setRecentColors: ActionCreator<SetRecentColorsAction>;
     selectedAgentMetadata: AgentMetadata;
 }
@@ -81,7 +81,7 @@ const ModelPanel: React.FC<ModelPanelProps> = ({
     isNetworkedFile,
     changeToNetworkedFile: loadNetworkFile,
     recentColors,
-    setColorChange,
+    applyUserColorSelection,
     setRecentColors,
     selectedAgentMetadata,
 }): JSX.Element => {
@@ -97,7 +97,7 @@ const ModelPanel: React.FC<ModelPanelProps> = ({
             payloadForSelectNone={payloadForSelectNone}
             isSharedCheckboxIndeterminate={isSharedCheckboxIndeterminate}
             recentColors={recentColors}
-            setColorChange={setColorChange}
+            applyUserColorSelection={applyUserColorSelection}
             setRecentColors={setRecentColors}
         />
     );
@@ -147,7 +147,7 @@ const dispatchToPropsMap = {
     turnAgentsOnByDisplayKey,
     highlightAgentsByDisplayKey,
     setAgentsVisible,
-    setColorChange,
+    applyUserColorSelection,
     setRecentColors,
 };
 

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -83,7 +83,7 @@ interface ViewerPanelProps {
     changeTime: ActionCreator<ChangeTimeAction>;
     receiveAgentTypeIds: ActionCreator<ReceiveAction>;
     receiveTrajectory: ActionCreator<ReceiveAction>;
-    receiveAgentNamesAndStates: ActionCreator<ReceiveAction>;
+    setDefaultUIData: ActionCreator<ReceiveAction>;
     selectionStateInfoForViewer: SelectionStateInfo;
     setIsPlaying: ActionCreator<ToggleAction>;
     setIsLooping: ActionCreator<ToggleAction>;
@@ -376,11 +376,11 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     }
 
     public handleUiDisplayDataChanged = (uiData: UIDisplayData) => {
-        const { receiveAgentNamesAndStates, setAgentsVisible } = this.props;
+        const { setDefaultUIData, setAgentsVisible } = this.props;
 
         const selectedAgents = convertUIDataToSelectionData(uiData);
         const actions = [
-            receiveAgentNamesAndStates(uiData),
+            setDefaultUIData(uiData),
             setAgentsVisible(selectedAgents),
         ];
         batchActions(actions);
@@ -571,8 +571,7 @@ const dispatchToPropsMap = {
     setAgentsVisible: selectionStateBranch.actions.setAgentsVisible,
     receiveTrajectory: trajectoryStateBranch.actions.receiveTrajectory,
     receiveAgentTypeIds: trajectoryStateBranch.actions.receiveAgentTypeIds,
-    receiveAgentNamesAndStates:
-        trajectoryStateBranch.actions.receiveAgentNamesAndStates,
+    setDefaultUIData: trajectoryStateBranch.actions.setDefaultUIData,
     setStatus: viewerStateBranch.actions.setStatus,
     dragOverViewer: viewerStateBranch.actions.dragOverViewer,
     resetDragOverViewer: viewerStateBranch.actions.resetDragOverViewer,

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -6,7 +6,7 @@ import {
     getTimeStep,
     getFirstFrameTimeOfCachedSimulation,
     getSimulariumFile,
-    getAgentDisplayNamesAndStates,
+    getDefaultUIData,
 } from "../../state/trajectory/selectors";
 import {
     getAgentsToHide,
@@ -19,7 +19,7 @@ import { DisplayTimes } from "./types";
 import { isNetworkSimFileInterface } from "../../state/trajectory/types";
 
 export const getSelectionStateInfoForViewer = createSelector(
-    [getHighlightedAgents, getAgentsToHide, getAgentDisplayNamesAndStates],
+    [getHighlightedAgents, getAgentsToHide, getDefaultUIData],
     (highlightedAgents, hiddenAgents, appliedColors): SelectionStateInfo => ({
         highlightedAgents,
         hiddenAgents,

--- a/src/state/selection/actions.ts
+++ b/src/state/selection/actions.ts
@@ -7,9 +7,9 @@ import {
     HIGHLIGHT_AGENTS_BY_KEY,
     SET_AGENTS_VISIBLE,
     RESET_AGENT_SELECTIONS_AND_HIGHLIGHTS,
-    SET_COLOR_CHANGES,
     SET_RECENT_COLORS,
     SET_SELECTED_AGENT,
+    APPLY_USER_COLOR_SELECTION,
 } from "./constants";
 import {
     ChangeAgentsRenderingStateAction,
@@ -18,7 +18,7 @@ import {
     SetVisibleAction,
     AgentRenderingCheckboxMap,
     ResetAction,
-    SetColorChangeAction,
+    ApplyUserColorSelectionAction,
     SetRecentColorsAction,
     SetSelectedAgentMetadataAction,
 } from "./types";
@@ -64,10 +64,12 @@ export function highlightAgentsByDisplayKey(
     };
 }
 
-export function setColorChange(colorChange: ColorChange): SetColorChangeAction {
+export function applyUserColorSelection(
+    payload: ColorChange
+): ApplyUserColorSelectionAction {
     return {
-        payload: colorChange,
-        type: SET_COLOR_CHANGES,
+        payload,
+        type: APPLY_USER_COLOR_SELECTION,
     };
 }
 

--- a/src/state/selection/constants.ts
+++ b/src/state/selection/constants.ts
@@ -18,6 +18,8 @@ export const SET_AGENTS_VISIBLE = makeSelectConstant("set-agents-visible");
 export const RESET_AGENT_SELECTIONS_AND_HIGHLIGHTS = makeSelectConstant(
     "reset-selections-and-highlighted-agents"
 );
-export const SET_COLOR_CHANGES = makeSelectConstant("set-color-changes");
+export const APPLY_USER_COLOR_SELECTION = makeSelectConstant(
+    "apply-user-color-selection"
+);
 export const SET_RECENT_COLORS = makeSelectConstant("set-recent-colors");
 export const SET_SELECTED_AGENT = makeSelectConstant("set-selected-agent");

--- a/src/state/selection/logics.ts
+++ b/src/state/selection/logics.ts
@@ -1,10 +1,10 @@
 import { createLogic } from "redux-logic";
 import { UIDisplayData } from "@aics/simularium-viewer";
 
-import { SET_COLOR_CHANGES } from "./constants";
 import { ReduxLogicDeps } from "../types";
 import { getDefaultUIData } from "../trajectory/selectors";
 import { setDefaultUIData } from "../trajectory/actions";
+import { APPLY_USER_COLOR_SELECTION } from "./constants";
 
 const storeColorsLogic = createLogic({
     process(deps: ReduxLogicDeps, dispatch, done) {
@@ -35,7 +35,7 @@ const storeColorsLogic = createLogic({
         dispatch(setDefaultUIData(newUiData));
         done();
     },
-    type: SET_COLOR_CHANGES,
+    type: APPLY_USER_COLOR_SELECTION,
 });
 
 export default [storeColorsLogic];

--- a/src/state/selection/logics.ts
+++ b/src/state/selection/logics.ts
@@ -3,13 +3,13 @@ import { UIDisplayData } from "@aics/simularium-viewer";
 
 import { SET_COLOR_CHANGES } from "./constants";
 import { ReduxLogicDeps } from "../types";
-import { getAgentDisplayNamesAndStates } from "../trajectory/selectors";
-import { receiveAgentNamesAndStates } from "../trajectory/actions";
+import { getDefaultUIData } from "../trajectory/selectors";
+import { setDefaultUIData } from "../trajectory/actions";
 
 const storeColorsLogic = createLogic({
     process(deps: ReduxLogicDeps, dispatch, done) {
         const { action, getState } = deps;
-        const uiData: UIDisplayData = getAgentDisplayNamesAndStates(getState());
+        const uiData: UIDisplayData = getDefaultUIData(getState());
         const colorChange = action.payload;
         const newUiData = uiData.map((agent) => {
             const newAgent = { ...agent };
@@ -32,7 +32,7 @@ const storeColorsLogic = createLogic({
             }
             return newAgent;
         });
-        dispatch(receiveAgentNamesAndStates(newUiData));
+        dispatch(setDefaultUIData(newUiData));
         done();
     },
     type: SET_COLOR_CHANGES,

--- a/src/state/selection/selectors/index.ts
+++ b/src/state/selection/selectors/index.ts
@@ -2,13 +2,13 @@ import { createSelector } from "reselect";
 import { reduce } from "lodash";
 import { SelectionEntry, UIDisplayData } from "@aics/simularium-viewer";
 
-import { getAgentDisplayNamesAndStates } from "../../trajectory/selectors";
+import { getDefaultUIData } from "../../trajectory/selectors";
 import { AgentRenderingCheckboxMap } from "../types";
 
 import { getAgentHighlightMap, getAgentVisibilityMap } from "./basic";
 
 export const getHighlightedAgents = createSelector(
-    [getAgentHighlightMap, getAgentDisplayNamesAndStates],
+    [getAgentHighlightMap, getDefaultUIData],
     (
         highlightedAgents: AgentRenderingCheckboxMap,
         allAgents: UIDisplayData
@@ -50,7 +50,7 @@ export const getHighlightedAgents = createSelector(
 );
 
 export const getAgentsToHide = createSelector(
-    [getAgentVisibilityMap, getAgentDisplayNamesAndStates],
+    [getAgentVisibilityMap, getDefaultUIData],
     (
         agentVisibilityMap: AgentRenderingCheckboxMap,
         agentDisplayData: UIDisplayData

--- a/src/state/selection/types.ts
+++ b/src/state/selection/types.ts
@@ -67,7 +67,7 @@ export interface ResetAction {
     type: string;
 }
 
-export interface SetColorChangeAction {
+export interface ApplyUserColorSelectionAction {
     payload: ColorChange;
     type: string;
 }

--- a/src/state/trajectory/actions.ts
+++ b/src/state/trajectory/actions.ts
@@ -1,10 +1,9 @@
-import { SimulariumController } from "@aics/simularium-viewer";
+import { SimulariumController, UIDisplayData } from "@aics/simularium-viewer";
 
 import {
     RECEIVE_TRAJECTORY,
     REQUEST_TRAJECTORY,
     RECEIVE_AGENT_IDS,
-    RECEIVE_AGENT_NAMES,
     RECEIVE_SIMULARIUM_FILE,
     LOAD_LOCAL_FILE_IN_VIEWER,
     LOAD_NETWORKED_FILE_IN_VIEWER,
@@ -20,6 +19,7 @@ import {
     RECEIVE_CONVERTED_FILE,
     CANCEL_CONVERSION,
     SET_CONVERSION_TITLE,
+    SET_DEFAULT_UI_DATA,
 } from "./constants";
 import { AvailableEngines } from "./conversion-data-types";
 import {
@@ -42,6 +42,7 @@ import {
     ConversionStatus,
     CancelConversionAction,
     SetConversionTitleAction,
+    SetDefaultUIDataAction,
 } from "./types";
 
 export function receiveTrajectory(
@@ -74,15 +75,6 @@ export function receiveAgentTypeIds(
     return {
         payload,
         type: RECEIVE_AGENT_IDS,
-    };
-}
-
-export function receiveAgentNamesAndStates(
-    payload: TrajectoryStateBranch
-): ReceiveAction {
-    return {
-        payload,
-        type: RECEIVE_AGENT_NAMES,
     };
 }
 
@@ -203,5 +195,14 @@ export function receiveConvertedFile(payload: NetworkedSimFile): ReceiveAction {
 export function cancelAutoconversion(): CancelConversionAction {
     return {
         type: CANCEL_CONVERSION,
+    };
+}
+
+export function setDefaultUIData(
+    payload: UIDisplayData
+): SetDefaultUIDataAction {
+    return {
+        payload,
+        type: SET_DEFAULT_UI_DATA,
     };
 }

--- a/src/state/trajectory/constants.ts
+++ b/src/state/trajectory/constants.ts
@@ -7,9 +7,6 @@ const makeTrajectoryConstant = (constant: string) =>
 export const RECEIVE_TRAJECTORY = makeTrajectoryConstant("receive");
 export const REQUEST_TRAJECTORY = makeTrajectoryConstant("request");
 export const RECEIVE_AGENT_IDS = makeTrajectoryConstant("receive-ids");
-export const RECEIVE_AGENT_NAMES = makeTrajectoryConstant(
-    "receive-agent-names"
-);
 export const RECEIVE_SIMULARIUM_FILE = makeTrajectoryConstant(
     "receive-simularium-file"
 );
@@ -42,4 +39,7 @@ export const CANCEL_CONVERSION = makeTrajectoryConstant("cancel-conversion");
 export const SET_CONVERSION_STATUS = makeTrajectoryConstant("set-status");
 export const SET_CONVERSION_TITLE = makeTrajectoryConstant(
     "set-conversion-title"
+);
+export const SET_DEFAULT_UI_DATA = makeTrajectoryConstant(
+    "set-default-ui-data"
 );

--- a/src/state/trajectory/reducer.ts
+++ b/src/state/trajectory/reducer.ts
@@ -6,7 +6,7 @@ import { makeReducer } from "../util";
 import {
     RECEIVE_TRAJECTORY,
     RECEIVE_AGENT_IDS,
-    RECEIVE_AGENT_NAMES,
+    SET_DEFAULT_UI_DATA,
     RECEIVE_SIMULARIUM_FILE,
     CLEAR_SIMULARIUM_FILE,
     SET_CONVERSION_TEMPLATE,
@@ -28,6 +28,7 @@ import {
     ConversionStatus,
     ConvertFileAction,
     SetConversionTitleAction,
+    SetDefaultUIDataAction,
 } from "./types";
 
 export const initialState = {
@@ -37,7 +38,7 @@ export const initialState = {
     timeUnits: null,
     scaleBarLabel: "",
     agentIds: [],
-    agentUiNames: [],
+    defaultUIData: [],
     plotData: [],
     simulariumFile: {
         name: "",
@@ -71,14 +72,6 @@ const actionToConfigMap: TypeToDescriptionMap = {
         perform: (state: TrajectoryStateBranch, action: ReceiveAction) => ({
             ...state,
             agentIds: action.payload,
-        }),
-    },
-    [RECEIVE_AGENT_NAMES]: {
-        accepts: (action: AnyAction): action is ReceiveAction =>
-            action.type === RECEIVE_AGENT_NAMES,
-        perform: (state: TrajectoryStateBranch, action: ReceiveAction) => ({
-            ...state,
-            agentUiNames: action.payload,
         }),
     },
     [RECEIVE_SIMULARIUM_FILE]: {
@@ -188,6 +181,19 @@ const actionToConfigMap: TypeToDescriptionMap = {
             simulariumFile: action.payload,
             processingData: initialState.processingData,
         }),
+    },
+    [SET_DEFAULT_UI_DATA]: {
+        accepts: (action: AnyAction): action is SetDefaultUIDataAction =>
+            action.type === SET_DEFAULT_UI_DATA,
+        perform: (
+            state: TrajectoryStateBranch,
+            action: SetDefaultUIDataAction
+        ) => {
+            return {
+                ...state,
+                defaultUIData: action.payload,
+            };
+        },
     },
 };
 

--- a/src/state/trajectory/selectors/basic.ts
+++ b/src/state/trajectory/selectors/basic.ts
@@ -12,9 +12,9 @@ export const getScaleBarLabel = (state: State) =>
     state.trajectory.scaleBarLabel;
 export const getSimulariumFile = (state: State) =>
     state.trajectory.simulariumFile;
-export const getAgentDisplayNamesAndStates = (state: State) =>
-    state.trajectory.agentUiNames;
 export const getConversionProcessingData = (state: State) =>
     state.trajectory.processingData;
 export const getConversionStatus = (state: State) =>
     state.trajectory.conversionStatus;
+export const getDefaultUIData = (state: State) =>
+    state.trajectory.defaultUIData;

--- a/src/state/trajectory/selectors/index.ts
+++ b/src/state/trajectory/selectors/index.ts
@@ -6,7 +6,7 @@ import {
     LocalSimFile,
     NetworkedSimFile,
 } from "../types";
-import { getSimulariumFile, getAgentDisplayNamesAndStates } from "./basic";
+import { getSimulariumFile, getDefaultUIData } from "./basic";
 
 export const getIsNetworkedFile = createSelector(
     [getSimulariumFile],
@@ -19,7 +19,7 @@ export const getIsNetworkedFile = createSelector(
 );
 
 export const getUiDisplayDataTree = createSelector(
-    [getAgentDisplayNamesAndStates],
+    [getDefaultUIData],
     (uiDisplayData: UIDisplayData) => {
         if (!uiDisplayData.length) {
             return [];

--- a/src/state/trajectory/types.ts
+++ b/src/state/trajectory/types.ts
@@ -1,4 +1,8 @@
-import { ISimulariumFile, SimulariumController } from "@aics/simularium-viewer";
+import {
+    ISimulariumFile,
+    SimulariumController,
+    UIDisplayData,
+} from "@aics/simularium-viewer";
 import {
     AvailableEngines,
     Template,
@@ -126,4 +130,8 @@ export enum ConversionStatus {
     NoServer = "CONVERSION_NO_SERVER",
     ServerConfirmed = "CONVERSION_SERVER_CONFIRMED",
     Active = "CONVERSION_ACTIVE",
+}
+export interface SetDefaultUIDataAction {
+    payload: UIDisplayData;
+    type: string;
 }


### PR DESCRIPTION
Time estimate or Size
_tiny_

Problem
=======
Color sessions PR is large and cumbersome, these changes are all just renaming of existing redux plumbing that should not effect functionality, stripping these non-functional changes out into separate PR to improve readability there.

New names makes sense in the context of new feature if they are not obvious to you, so please refer to that PR or [this closed PR](https://github.com/simularium/simularium-website/pull/545) for context if desired.

Solution
========
agentUiNames/receiveAgentNamesAndState -> defaultUIData
setColorChanges -> applyUserColorSelections