### PR TITLE
Feature/selector org

### DIFF
--- a/src/containers/ModelPanel/index.tsx
+++ b/src/containers/ModelPanel/index.tsx
@@ -10,10 +10,7 @@ import {
     requestTrajectory,
     changeToNetworkedFile,
 } from "../../state/trajectory/actions";
-import {
-    getUiDisplayDataTree,
-    getIsNetworkedFile,
-} from "../../state/trajectory/selectors";
+import { getIsNetworkedFile } from "../../state/trajectory/selectors";
 import {
     AgentRenderingCheckboxMap,
     ChangeAgentsRenderingStateAction,
@@ -44,6 +41,7 @@ import {
     getSelectAllVisibilityMap,
     getSelectNoneVisibilityMap,
     getIsSharedCheckboxIndeterminate,
+    getUiDisplayDataTree,
 } from "./selectors";
 
 import styles from "./style.css";

--- a/src/containers/ModelPanel/selectors.test.ts
+++ b/src/containers/ModelPanel/selectors.test.ts
@@ -1,7 +1,9 @@
+import { initialState, State } from "../../state";
 import {
     getSelectAllVisibilityMap,
     getSelectNoneVisibilityMap,
     getIsSharedCheckboxIndeterminate,
+    getUiDisplayDataTree,
 } from "./selectors";
 
 const mockUiDisplayData = [
@@ -50,9 +52,8 @@ const mockUiDisplayData = [
 describe("ModelPanel selectors", () => {
     describe("getSelectAllVisibilityMap", () => {
         it("Returns an agent visibility map with all possible states", () => {
-            const result = getSelectAllVisibilityMap.resultFunc(
-                mockUiDisplayData
-            );
+            const result =
+                getSelectAllVisibilityMap.resultFunc(mockUiDisplayData);
             const expected = {
                 agentWithChildren1: ["", "state1"],
                 agentWithChildren2: ["", "state1"],
@@ -64,9 +65,8 @@ describe("ModelPanel selectors", () => {
 
     describe("getSelectNoneVisibilityMap", () => {
         it("Returns an agent visibility map with none of the possible states", () => {
-            const result = getSelectNoneVisibilityMap.resultFunc(
-                mockUiDisplayData
-            );
+            const result =
+                getSelectNoneVisibilityMap.resultFunc(mockUiDisplayData);
             const expected = {
                 agentWithChildren1: [],
                 agentWithChildren2: [],
@@ -162,6 +162,69 @@ describe("ModelPanel selectors", () => {
                 mockAgentVisibilityMap
             );
             expect(result).toBe(true);
+        });
+    });
+    describe("getUiDisplayDataTree", () => {
+        it("returns an empty array if ui display data is empty", () => {
+            expect(getUiDisplayDataTree(initialState)).toStrictEqual([]);
+        });
+        it("correctly maps agent display info to an array of display data", () => {
+            const state: State = {
+                ...initialState,
+                trajectory: {
+                    ...initialState.trajectory,
+                    defaultUIData: [
+                        {
+                            name: "agent1",
+                            displayStates: [],
+                            color: "#bbbbbb",
+                        },
+                        {
+                            name: "agent2",
+                            color: "#aaaaaa",
+                            displayStates: [
+                                {
+                                    name: "state1",
+                                    id: "state1_id",
+                                    color: "#000000",
+                                },
+                                {
+                                    name: "state2",
+                                    id: "state2_id",
+                                    color: "#000000",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            };
+
+            const expected = [
+                {
+                    title: "agent1",
+                    key: "agent1",
+                    children: [],
+                    color: "#bbbbbb",
+                },
+                {
+                    title: "agent2",
+                    key: "agent2",
+                    color: "#aaaaaa",
+                    children: [
+                        {
+                            color: "#000000",
+                            label: "state1",
+                            value: "state1_id",
+                        },
+                        {
+                            color: "#000000",
+                            label: "state2",
+                            value: "state2_id",
+                        },
+                    ],
+                },
+            ];
+            expect(getUiDisplayDataTree(state)).toStrictEqual(expected);
         });
     });
 });

--- a/src/containers/ModelPanel/selectors.ts
+++ b/src/containers/ModelPanel/selectors.ts
@@ -2,9 +2,33 @@ import { createSelector } from "reselect";
 import { isEmpty } from "lodash";
 
 import { AgentDisplayNode } from "../../components/AgentTree";
-import { getUiDisplayDataTree } from "../../state/trajectory/selectors";
 import { getAgentVisibilityMap } from "../../state/selection/selectors";
 import { AgentRenderingCheckboxMap } from "../../state/selection/types";
+import { getCurrentUIData } from "../../state/compoundSelectors";
+import { UIDisplayData } from "@aics/simularium-viewer";
+
+export const getUiDisplayDataTree = createSelector(
+    [getCurrentUIData],
+    (uiDisplayData: UIDisplayData) => {
+        if (!uiDisplayData.length) {
+            return [];
+        }
+        return uiDisplayData.map((agent) => ({
+            title: agent.name,
+            key: agent.name,
+            color: agent.color,
+            children: agent.displayStates.length
+                ? [
+                      ...agent.displayStates.map((state) => ({
+                          label: state.name,
+                          value: state.id,
+                          color: state.color,
+                      })),
+                  ]
+                : [],
+        }));
+    }
+);
 
 // Returns an agent visibility map that indicates all states should be visible
 export const getSelectAllVisibilityMap = createSelector(

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -11,15 +11,15 @@ import {
     getAgentsToHide,
     getCurrentTime,
     getHighlightedAgents,
-    getSelectedUIDisplayData,
 } from "../../state/selection/selectors";
 import { AgentRenderingCheckboxMap } from "../../state/selection/types";
 import { roundTimeForDisplay } from "../../util";
 import { DisplayTimes } from "./types";
 import { isNetworkSimFileInterface } from "../../state/trajectory/types";
+import { getCurrentUIData } from "../../state/compoundSelectors";
 
 export const getSelectionStateInfoForViewer = createSelector(
-    [getHighlightedAgents, getAgentsToHide, getSelectedUIDisplayData],
+    [getHighlightedAgents, getAgentsToHide, getCurrentUIData],
     (highlightedAgents, hiddenAgents, appliedColors): SelectionStateInfo => ({
         highlightedAgents,
         hiddenAgents,

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -11,15 +11,15 @@ import {
     getAgentsToHide,
     getCurrentTime,
     getHighlightedAgents,
+    getSelectedUIDisplayData,
 } from "../../state/selection/selectors";
 import { AgentRenderingCheckboxMap } from "../../state/selection/types";
 import { roundTimeForDisplay } from "../../util";
 import { DisplayTimes } from "./types";
 import { isNetworkSimFileInterface } from "../../state/trajectory/types";
-import { getCurrentUIData } from "../../state/compoundSelectors";
 
 export const getSelectionStateInfoForViewer = createSelector(
-    [getHighlightedAgents, getAgentsToHide, getCurrentUIData],
+    [getHighlightedAgents, getAgentsToHide, getSelectedUIDisplayData],
     (highlightedAgents, hiddenAgents, appliedColors): SelectionStateInfo => ({
         highlightedAgents,
         hiddenAgents,

--- a/src/state/compoundSelectors/compoundSelectors.test.ts
+++ b/src/state/compoundSelectors/compoundSelectors.test.ts
@@ -1,0 +1,78 @@
+import { getCurrentUIData } from ".";
+import { initialState } from "..";
+import { ColorSettings } from "../selection/types";
+
+describe("getCurrentUIData", () => {
+    it("returns empty array if default UI data has not been entered yet", () => {
+        expect(getCurrentUIData(initialState)).toEqual([]);
+    });
+    it("returns selectedUIDisplayData if colorSetting is equal to ColorSettings.UserSelected", () => {
+        expect(
+            getCurrentUIData({
+                ...initialState,
+                trajectory: {
+                    ...initialState.trajectory,
+                    defaultUIData: [
+                        {
+                            name: "agent1",
+                            displayStates: [],
+                            color: "#bbbbbb",
+                        },
+                    ],
+                },
+                selection: {
+                    ...initialState.selection,
+                    currentColorSettings: ColorSettings.UserSelected,
+                    selectedUIDisplayData: [
+                        {
+                            name: "agent1",
+                            displayStates: [],
+                            color: "#000",
+                        },
+                    ],
+                },
+            })
+        ).toEqual([
+            {
+                name: "agent1",
+                displayStates: [],
+                color: "#000",
+            },
+        ]);
+    });
+
+    it("returns defaultUIData if colorSetting is euqal to ColorSettings.Default", () => {
+        expect(
+            getCurrentUIData({
+                ...initialState,
+                trajectory: {
+                    ...initialState.trajectory,
+                    defaultUIData: [
+                        {
+                            name: "agent1",
+                            displayStates: [],
+                            color: "#bbbbbb",
+                        },
+                    ],
+                },
+                selection: {
+                    ...initialState.selection,
+                    currentColorSettings: ColorSettings.Default,
+                    selectedUIDisplayData: [
+                        {
+                            name: "agent1",
+                            displayStates: [],
+                            color: "#000",
+                        },
+                    ],
+                },
+            })
+        ).toEqual([
+            {
+                name: "agent1",
+                displayStates: [],
+                color: "#bbbbbb",
+            },
+        ]);
+    });
+});

--- a/src/state/compoundSelectors/compoundSelectors.test.ts
+++ b/src/state/compoundSelectors/compoundSelectors.test.ts
@@ -5,6 +5,7 @@ import { ColorSetting } from "../selection/types";
 describe("getCurrentUIData", () => {
     it("returns empty array if default UI data has not been entered yet", () => {
         expect(getCurrentUIData(initialState)).toEqual([]);
+        1;
     });
     it("returns selectedUIDisplayData if colorSetting is equal to ColorSetting.UserSelected", () => {
         expect(
@@ -22,7 +23,7 @@ describe("getCurrentUIData", () => {
                 },
                 selection: {
                     ...initialState.selection,
-                    current: ColorSetting.UserSelected,
+                    currentColorSetting: ColorSetting.UserSelected,
                     selectedUIDisplayData: [
                         {
                             name: "agent1",

--- a/src/state/compoundSelectors/compoundSelectors.test.ts
+++ b/src/state/compoundSelectors/compoundSelectors.test.ts
@@ -1,12 +1,12 @@
 import { getCurrentUIData } from ".";
 import { initialState } from "..";
-import { ColorSettings } from "../selection/types";
+import { ColorSetting } from "../selection/types";
 
 describe("getCurrentUIData", () => {
     it("returns empty array if default UI data has not been entered yet", () => {
         expect(getCurrentUIData(initialState)).toEqual([]);
     });
-    it("returns selectedUIDisplayData if colorSetting is equal to ColorSettings.UserSelected", () => {
+    it("returns selectedUIDisplayData if colorSetting is equal to ColorSetting.UserSelected", () => {
         expect(
             getCurrentUIData({
                 ...initialState,
@@ -22,7 +22,7 @@ describe("getCurrentUIData", () => {
                 },
                 selection: {
                     ...initialState.selection,
-                    currentColorSettings: ColorSettings.UserSelected,
+                    current: ColorSetting.UserSelected,
                     selectedUIDisplayData: [
                         {
                             name: "agent1",
@@ -41,7 +41,7 @@ describe("getCurrentUIData", () => {
         ]);
     });
 
-    it("returns defaultUIData if colorSetting is euqal to ColorSettings.Default", () => {
+    it("returns defaultUIData if colorSetting is euqal to ColorSetting.Default", () => {
         expect(
             getCurrentUIData({
                 ...initialState,
@@ -57,7 +57,7 @@ describe("getCurrentUIData", () => {
                 },
                 selection: {
                     ...initialState.selection,
-                    currentColorSettings: ColorSettings.Default,
+                    currentColorSetting: ColorSetting.Default,
                     selectedUIDisplayData: [
                         {
                             name: "agent1",

--- a/src/state/compoundSelectors/index.ts
+++ b/src/state/compoundSelectors/index.ts
@@ -8,6 +8,13 @@ import {
 } from "../selection/selectors";
 import { ColorSetting } from "../selection/types";
 
+/**
+ * compoundSelectors are selectors that consume state from multiple branches
+ * of state, so don't belong in a particular branch's selectors file,
+ * and are consumed by multiple containers, and so don't belong in a particular
+ * container's selectors file.
+ */
+
 export const getCurrentUIData = createSelector(
     [getCurrentColorSetting, getSelectedUIDisplayData, getDefaultUIDisplayData],
     (

--- a/src/state/compoundSelectors/index.ts
+++ b/src/state/compoundSelectors/index.ts
@@ -1,0 +1,31 @@
+import { createSelector } from "reselect";
+
+import { getDefaultUIDisplayData } from "../trajectory/selectors";
+import {
+    getCurrentColorSettings,
+    getSelectedUIDisplayData,
+} from "../selection/selectors";
+import { ColorSettings } from "../selection/types";
+import { UIDisplayData } from "@aics/simularium-viewer";
+
+export const getCurrentUIData = createSelector(
+    [
+        getCurrentColorSettings,
+        getSelectedUIDisplayData,
+        getDefaultUIDisplayData,
+    ],
+    (
+        colorSetting: ColorSettings,
+        sessionData: UIDisplayData,
+        defaultData: UIDisplayData
+    ) => {
+        const fileHasBeenParsed = defaultData.length > 0;
+        if (!fileHasBeenParsed) {
+            return [];
+        }
+        if (colorSetting === ColorSettings.UserSelected) {
+            return sessionData;
+        }
+        return defaultData;
+    }
+);

--- a/src/state/compoundSelectors/index.ts
+++ b/src/state/compoundSelectors/index.ts
@@ -1,21 +1,17 @@
 import { createSelector } from "reselect";
+import { UIDisplayData } from "@aics/simularium-viewer";
 
 import { getDefaultUIDisplayData } from "../trajectory/selectors";
 import {
-    getCurrentColorSettings,
+    getCurrentColorSetting,
     getSelectedUIDisplayData,
 } from "../selection/selectors";
-import { ColorSettings } from "../selection/types";
-import { UIDisplayData } from "@aics/simularium-viewer";
+import { ColorSetting } from "../selection/types";
 
 export const getCurrentUIData = createSelector(
-    [
-        getCurrentColorSettings,
-        getSelectedUIDisplayData,
-        getDefaultUIDisplayData,
-    ],
+    [getCurrentColorSetting, getSelectedUIDisplayData, getDefaultUIDisplayData],
     (
-        colorSetting: ColorSettings,
+        colorSetting: ColorSetting,
         sessionData: UIDisplayData,
         defaultData: UIDisplayData
     ) => {
@@ -23,7 +19,7 @@ export const getCurrentUIData = createSelector(
         if (!fileHasBeenParsed) {
             return [];
         }
-        if (colorSetting === ColorSettings.UserSelected) {
+        if (colorSetting === ColorSetting.UserSelected) {
             return sessionData;
         }
         return defaultData;

--- a/src/state/selection/reducer.ts
+++ b/src/state/selection/reducer.ts
@@ -26,6 +26,7 @@ import {
     SetRecentColorsAction,
     SetSelectedAgentMetadataAction,
     SetSelectedUIDisplayDataAction,
+    ColorSettings,
 } from "./types";
 
 export const initialState = {
@@ -36,6 +37,7 @@ export const initialState = {
     recentColors: [],
     selectedAgentMetadata: {},
     selectedUIDisplayData: [],
+    currentColorSettings: ColorSettings.Default,
 };
 
 const actionToConfigMap: TypeToDescriptionMap = {

--- a/src/state/selection/reducer.ts
+++ b/src/state/selection/reducer.ts
@@ -26,7 +26,7 @@ import {
     SetRecentColorsAction,
     SetSelectedAgentMetadataAction,
     SetSelectedUIDisplayDataAction,
-    ColorSettings,
+    ColorSetting,
 } from "./types";
 
 export const initialState = {
@@ -37,7 +37,7 @@ export const initialState = {
     recentColors: [],
     selectedAgentMetadata: {},
     selectedUIDisplayData: [],
-    currentColorSettings: ColorSettings.Default,
+    currentColorSetting: ColorSetting.Default,
 };
 
 const actionToConfigMap: TypeToDescriptionMap = {

--- a/src/state/selection/selectors/basic.ts
+++ b/src/state/selection/selectors/basic.ts
@@ -13,5 +13,5 @@ export const getSelectedAgentMetadata = (state: State) =>
     state.selection.selectedAgentMetadata;
 export const getSelectedUIDisplayData = (state: State) =>
     state.selection.selectedUIDisplayData;
-export const getCurrentColorSettings = (state: State) =>
-    state.selection.currentColorSettings;
+export const getCurrentColorSetting = (state: State) =>
+    state.selection.currentColorSetting;

--- a/src/state/selection/selectors/basic.ts
+++ b/src/state/selection/selectors/basic.ts
@@ -13,3 +13,5 @@ export const getSelectedAgentMetadata = (state: State) =>
     state.selection.selectedAgentMetadata;
 export const getSelectedUIDisplayData = (state: State) =>
     state.selection.selectedUIDisplayData;
+export const getCurrentColorSettings = (state: State) =>
+    state.selection.currentColorSettings;

--- a/src/state/selection/types.ts
+++ b/src/state/selection/types.ts
@@ -88,7 +88,7 @@ export interface SetSelectedUIDisplayDataAction {
     type: string;
 }
 
-export enum ColorSettings {
+export enum ColorSetting {
     UserSelected = "userSelected",
     Default = "default",
 }

--- a/src/state/selection/types.ts
+++ b/src/state/selection/types.ts
@@ -87,3 +87,8 @@ export interface SetSelectedUIDisplayDataAction {
     payload: UIDisplayData;
     type: string;
 }
+
+export enum ColorSettings {
+    UserSelected = "userSelected",
+    Default = "default",
+}

--- a/src/state/trajectory/selectors/index.ts
+++ b/src/state/trajectory/selectors/index.ts
@@ -1,12 +1,11 @@
 import { createSelector } from "reselect";
-import { UIDisplayData } from "@aics/simularium-viewer";
 
 import {
     isNetworkSimFileInterface,
     LocalSimFile,
     NetworkedSimFile,
 } from "../types";
-import { getSimulariumFile, getDefaultUIDisplayData } from "./basic";
+import { getSimulariumFile } from "./basic";
 
 export const getIsNetworkedFile = createSelector(
     [getSimulariumFile],
@@ -15,29 +14,6 @@ export const getIsNetworkedFile = createSelector(
             return false;
         }
         return isNetworkSimFileInterface(simFile);
-    }
-);
-
-export const getUiDisplayDataTree = createSelector(
-    [getDefaultUIDisplayData],
-    (uiDisplayData: UIDisplayData) => {
-        if (!uiDisplayData.length) {
-            return [];
-        }
-        return uiDisplayData.map((agent) => ({
-            title: agent.name,
-            key: agent.name,
-            color: agent.color,
-            children: agent.displayStates.length
-                ? [
-                      ...agent.displayStates.map((state) => ({
-                          label: state.name,
-                          value: state.id,
-                          color: state.color,
-                      })),
-                  ]
-                : [],
-        }));
     }
 );
 

--- a/src/state/trajectory/selectors/selectors.test.ts
+++ b/src/state/trajectory/selectors/selectors.test.ts
@@ -1,7 +1,7 @@
 import { initialState } from "../../index";
 import { State } from "../../types";
 
-import { getIsNetworkedFile, getUiDisplayDataTree } from ".";
+import { getIsNetworkedFile } from ".";
 
 describe("trajectory composed selectors", () => {
     describe("getIsNetworkedFile", () => {
@@ -35,71 +35,6 @@ describe("trajectory composed selectors", () => {
                 },
             };
             expect(getIsNetworkedFile(state)).toBe(true);
-        });
-    });
-
-    describe("getUiDisplayDataTree", () => {
-        it("returns an empty array if ui display data is empty", () => {
-            expect(getUiDisplayDataTree(initialState)).toStrictEqual([]);
-        });
-        it("correctly maps agent display info to an array of display data", () => {
-            const state: State = {
-                ...initialState,
-                trajectory: {
-                    ...initialState.trajectory,
-                    defaultUIData: [
-                        {
-                            name: "agent1",
-                            displayStates: [],
-                            color: "#bbbbbb",
-                        },
-                        {
-                            name: "agent2",
-                            color: "#aaaaaa",
-                            displayStates: [
-                                {
-                                    name: "state1",
-                                    id: "state1_id",
-                                    color: "#000000",
-                                },
-                                {
-                                    name: "state2",
-                                    id: "state2_id",
-                                    color: "#000000",
-                                },
-                            ],
-                        },
-                    ],
-                },
-            };
-
-            const expected = [
-                {
-                    title: "agent1",
-                    key: "agent1",
-                    children: [],
-                    color: "#bbbbbb",
-                },
-                {
-                    title: "agent2",
-                    key: "agent2",
-                    color: "#aaaaaa",
-                    children: [
-                        {
-                            color: "#000000",
-                            label: "state1",
-                            value: "state1_id",
-                        },
-                        {
-                            color: "#000000",
-                            label: "state2",
-                            value: "state2_id",
-                        },
-                    ],
-                },
-            ];
-
-            expect(getUiDisplayDataTree(state)).toStrictEqual(expected);
         });
     });
 });


### PR DESCRIPTION
Time estimate or Size
=======
_small/medium_
Changes related to directory organization, connected to #607, will not merge to main until both PRs are approved

Problem
=======
Advances #511 

Solution
========
@frasercl raised some interesting concerns about state branches in a previous PR

We have redux selectors in `/state` that are:
- basic selection of piece of state
- more complex derivation of state within a branch
- container specific selectors (`ModelPanel`, `ViewerPanel`, etc.)

Now adding `compoundSelectors` to `/state` to account for selectors that consume state from multiple branches and are used multiple containers.

This resolution keeps the actual data for `defaultUIDisplayData` in the `trajectory` branch and `selectedUIDisplayData` and `ColorSettings` in the `selection` branch, and avoids circular dependencies when the branches try to import each other's selectors.

This work is essentially part of #607, but so many lines of moving/organizing code was obscuring the readability of that PR. I will not merge either PR until both are approved. It is a non-breaking change, the app should run as before.

### getCurrentUIData
The selector which pulls from multiple branches to determine the current color settings for the app, and to pass to the viewer.

### getUiDisplayDataTree
Previously in `trajectory` moved to `ModelPanel` as it depends on a compound selector, and is only used in once place, could also be in `compoundSelectors` folder...

