### PR TITLE
fix: stop recording icon

### DIFF
--- a/src/components/RecordMoviesComponent/index.tsx
+++ b/src/components/RecordMoviesComponent/index.tsx
@@ -81,7 +81,7 @@ const RecordMovieComponent = (props: RecordMovieComponentProps) => {
         if (!isRecording) {
             return startRecordingIcon;
         } else if (isHovering) {
-            return "stop-record-icon";
+            return classNames("icon-moon", "stop-record-icon");
         } else return activeRecordingIcon;
     };
 

--- a/src/components/RecordMoviesComponent/index.tsx
+++ b/src/components/RecordMoviesComponent/index.tsx
@@ -63,14 +63,14 @@ const RecordMovieComponent = (props: RecordMovieComponentProps) => {
      * In this icon we are stacking glyphs to create multicolor icons via icomoon
      */
     const startRecordingIcon = (
-        <span className={styles.iconContainer}>
+        <div className={styles.iconContainer}>
             <span
                 className={classNames("icon-moon", "record-icon-circle")}
             ></span>
             <span
                 className={classNames("icon-moon", "record-icon-ring")}
             ></span>
-        </span>
+        </div>
     );
 
     const activeRecordingIcon = (
@@ -81,7 +81,11 @@ const RecordMovieComponent = (props: RecordMovieComponentProps) => {
         if (!isRecording) {
             return startRecordingIcon;
         } else if (isHovering) {
-            return classNames("icon-moon", "stop-record-icon");
+            return classNames(
+                styles.iconContainer,
+                "icon-moon",
+                "stop-record-icon"
+            );
         } else return activeRecordingIcon;
     };
 

--- a/src/components/RecordMoviesComponent/style.css
+++ b/src/components/RecordMoviesComponent/style.css
@@ -5,6 +5,8 @@
 }
 
 .icon-container {
+    display: flex;
+    align-items: center;
     height: 100%;
     width: 100%;
 }
@@ -22,18 +24,18 @@
 }
 
 @keyframes pulse-red {
-  0% {
-    transform: scale(0.95);
-    box-shadow: 0 0 0 0 #FF5252B3;
-  }
-  70% {
-    transform: scale(1);
-    box-shadow: 0 0 0 10px #FF525200;
-  }
-  100% {
-    transform: scale(0.95);
-    box-shadow: 0 0 0 0 #FF525200;
-  }
+    0% {
+        transform: scale(0.95);
+        box-shadow: 0 0 0 0 #ff5252b3;
+    }
+    70% {
+        transform: scale(1);
+        box-shadow: 0 0 0 10px #ff525200;
+    }
+    100% {
+        transform: scale(0.95);
+        box-shadow: 0 0 0 0 #ff525200;
+    }
 }
 
 .status-container {


### PR DESCRIPTION
Time estimate or Size
=======
_tiny_

Problem
=======
Closes #591 

class names for icon moon glyphs were not properly applied to the `stop-record` icon, also noticed positioning was off for both the main icon and the stop icon, so made a couple tweaks
