### PR TITLE
remove erroneous overflow bar

### DIFF
--- a/src/components/SideBarContents/style.css
+++ b/src/components/SideBarContents/style.css
@@ -2,7 +2,6 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    overflow-y: auto;
 }
 
 .container label {


### PR DESCRIPTION
Time estimate or Size
=======
_tiny_

Problem
=======
Empty viewer and trajectories with no plots were showing a scroll bar on the right side panel head.

Remove this overflow-y property. I think overflow styling on the side panels could use a touch up, but this is just buggy and needs a fix.

<img width="329" alt="Screenshot 2024-11-06 at 3 24 45 PM" src="https://github.com/user-attachments/assets/17b3e27d-6024-4874-8bd6-6d0333ba4dc2">
