### PR TITLE
bug fix: handle popstate among networked trajectories while on viewer path

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,8 +44,10 @@ function useLocationChange() {
                 dispatch(setIsPlaying(false));
                 dispatch(clearSimulariumFile({ newFile: false }));
             });
-            return;
         }
+    }, [location]);
+
+    React.useEffect(() => {
         const handlePopState = () => {
             if (window.location.pathname === VIEWER_PATHNAME) {
                 const trajectoryId = getUrlParamValue(
@@ -74,8 +76,10 @@ function useLocationChange() {
         };
 
         window.addEventListener("popstate", handlePopState);
-        return () => window.removeEventListener("popstate", handlePopState);
-    }, [location]);
+        return () => {
+            window.removeEventListener("popstate", handlePopState);
+        };
+    }, []);
 }
 
 const RouterSwitch = () => {


### PR DESCRIPTION
Time estimate or Size
=======
small

Problem
=======
Closes #617 
If you are at `/viewer` hitting back won't actually load the previous trajectory. Same for forward, bug reproduces with local files as well (i.e. navigating back to networked trajectory URL after loading local file).

Solution
========
Added a new `useEffect` and `handlePopState` to `useLocationChange`

Didn't work with the `[location]` dependency of previously existing `useEffect` so made a new one.