### PR TITLE
bug fix: only load drag and drop overlay if drag event contains file

### DIFF
--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -188,8 +188,11 @@ class App extends React.Component<AppProps, AppState> {
     public handleDragOverViewer(event: DragEvent) {
         const { dragOverViewer, fileIsDraggedOverViewer } = this.props;
         event.preventDefault();
+
+        const hasFiles = event.dataTransfer?.types.includes("Files");
+
         clearTimeout(this.endDragover);
-        if (!fileIsDraggedOverViewer) {
+        if (!fileIsDraggedOverViewer && hasFiles) {
             dragOverViewer();
         }
     }


### PR DESCRIPTION
Time estimate or Size
=======
_tiny_

Problem
=======
Closes #619 

Solution
========
Pretty straightforward fix, check for files before triggering drag and drop overlay.

I've known about this bug but was having trouble reliably reproducing it, finally figured out how to make the bug happen reliably so I chased it down.
