### PR TITLE
bump simularium-viewer to 3.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.13.0",
             "license": "ISC",
             "dependencies": {
-                "@aics/simularium-viewer": "^3.8.4",
+                "@aics/simularium-viewer": "^3.9.0",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "antd": "^4.23.6",
@@ -116,9 +116,10 @@
             "dev": true
         },
         "node_modules/@aics/simularium-viewer": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.8.4.tgz",
-            "integrity": "sha512-x3j26jRB8RrR+0ovrCt5DfGkNEJFPKZ9PMUluZ2megR8yEKlZPX+Qt65vKVhJJ+jQ7ybBy3dGyULqxc0fv4kmA==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.9.0.tgz",
+            "integrity": "sha512-cP4bW0tL7sd+ZyBT+68H3hHgmY6a/mFMF4u5v+af2I1BY1GqANp/bL6p9w8L9H94rzeHyorXizIJOzckEFlD9g==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.23.6",
                 "@babel/runtime": "^7.23.6",
@@ -128,13 +129,13 @@
                 "@fortawesome/react-fontawesome": "^0.1.14",
                 "@tweakpane/core": "^1.0.8",
                 "@tweakpane/plugin-essentials": "^0.1.4",
-                "@types/dom-webcodecs": "^0.1.8",
                 "comlink": "^4.3.1",
                 "js-logger": "^1.6.1",
+                "lodash": "^4.17.21",
                 "mp4-muxer": "^2.2.2",
                 "parse-pdb": "^1.0.0",
                 "si-prefix": "^0.2.0",
-                "three": "^0.137.4",
+                "three": "^0.144.0",
                 "tweakpane": "^3.0.7"
             },
             "peerDependencies": {
@@ -22795,9 +22796,10 @@
             "dev": true
         },
         "node_modules/three": {
-            "version": "0.137.5",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.137.5.tgz",
-            "integrity": "sha512-rTyr+HDFxjnN8+N/guZjDgfVxgHptZQpf6xfL/Mo7a5JYIFwK6tAq3bzxYYB4Ae0RosDZlDuP+X5aXDXz+XnHQ=="
+            "version": "0.144.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.144.0.tgz",
+            "integrity": "sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw==",
+            "license": "MIT"
         },
         "node_modules/throttle-debounce": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "webpack-dev-server": "^4.10.1"
     },
     "dependencies": {
-        "@aics/simularium-viewer": "^3.8.4",
+        "@aics/simularium-viewer": "^3.9.0",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "antd": "^4.23.6",


### PR DESCRIPTION
Review time: tiny

Bumps viewer to version 3.9.0, picking up some refactors, part of @interim17's new caching system, and most pertinently, an added hidden control for showing/hiding the bounding box which we've been asked to add ASAP.
