### PR TITLE
fix spacing on line gap

### DIFF
--- a/src/components/CustomDropdown/DropdownMenuItems.tsx
+++ b/src/components/CustomDropdown/DropdownMenuItems.tsx
@@ -24,7 +24,7 @@ const baseStyles = css`
     font-size: 14px;
 
     &&& {
-        align-items: baseline;
+        align-items: center;
         &:focus-visible,
         &:focus-visible:hover {
             outline: 1.5px solid ${({ theme }) => theme.colors.dropdown.active};

--- a/src/style.css
+++ b/src/style.css
@@ -69,6 +69,15 @@ canvas:focus {
 }
 
 @font-face {
+    font-family: "Overpass";
+    font-style: normal;
+    font-weight: 400;
+    src: url("https://fonts.gstatic.com/s/overpass/v20/qFdH35S-S5i3fKtE4HvUDvc.woff2")
+        format("woff2");
+    line-gap-override: 0;
+}
+
+@font-face {
     font-family: "icomoon";
     src: url("./assets/fonts/icomoon.eot?jthex9");
     src: url("./assets/fonts/icomoon.eot?jthex9#iefix")

--- a/src/style.css
+++ b/src/style.css
@@ -71,9 +71,8 @@ canvas:focus {
 @font-face {
     font-family: "Overpass";
     font-style: normal;
-    font-weight: 400;
-    src: url("https://fonts.gstatic.com/s/overpass/v20/qFdH35S-S5i3fKtE4HvUDvc.woff2")
-        format("woff2");
+    font-weight: normal;
+    src: url("https://fonts.googleapis.com/css2?family=Overpass:ital,wght@0,100..900;1,100..900&display=swap");
     line-gap-override: 0;
 }
 


### PR DESCRIPTION
Time estimate or Size
=======
Tiny

Problem
=======
Overpass font has a long standing ascent-override issue.

Google fonts officially *will not* update even though a fix exists because it would break too many production sites.

Finally figure out a fix, this PR applies the rule to the font and fixes spacing issues on the dropdown menu items.

Going forward we may find things to tweak, and in general aligning text and icons should get easier.

Merging into home page redesign branch will give a chance for multiple design reviews.

<img width="254" alt="Screenshot 2025-03-26 at 4 32 30 PM" src="https://github.com/user-attachments/assets/a80e4747-be47-4502-90cd-39b0f89f4444" />
<img width="220" alt="Screenshot 2025-03-26 at 4 32 20 PM" src="https://github.com/user-attachments/assets/ba314e2d-5c60-4444-ad0b-ae5a9de59b1c" />

