### PR TITLE
new fade out small screen warning

### DIFF
--- a/src/components/SmallScreenWarning/index.tsx
+++ b/src/components/SmallScreenWarning/index.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from "react";
+import { Cancel } from "../Icons";
+
+import styles from "./style.css";
+
+const FADE_DURATION_MS = 2000;
+
+const SmallScreenWarning = () => {
+    const [isVisible, setIsVisible] = useState(true);
+    const [isFading, setIsFading] = useState(false);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            triggerFade();
+        }, FADE_DURATION_MS);
+
+        return () => {
+            clearTimeout(timer);
+        };
+    }, []);
+
+    const triggerFade = () => {
+        if (!isFading) {
+            setIsFading(true);
+            setTimeout(() => {
+                setIsVisible(false);
+            }, FADE_DURATION_MS);
+        }
+    };
+
+    const handleClose = () => {
+        setIsVisible(false);
+    };
+
+    if (!isVisible) return null;
+
+    return (
+        <div
+            className={`${styles.warningContainer} ${
+                isFading ? styles.fadeOut : ""
+            }`}
+        >
+            <div className={styles.warningContent}>
+                <div>
+                    Tip: Simularium is experienced best on a larger screen size.
+                </div>
+                <button
+                    className={styles.closeButton}
+                    onClick={handleClose}
+                    aria-label="Close Warning"
+                >
+                    {Cancel}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default SmallScreenWarning;

--- a/src/components/SmallScreenWarning/style.css
+++ b/src/components/SmallScreenWarning/style.css
@@ -1,0 +1,36 @@
+.warningContainer {
+    position: absolute;
+    top: var(--header-height);
+    transform: translateX(-50%);
+    left: 50%;
+    color: var(--dark-theme-primary-color);
+    background-color: transparent;
+    border: 1px solid;
+    padding: 8px 6px 8px 10px;
+    transition: opacity 3s ease-out;
+    opacity: 1;
+    z-index: 100;
+    border-radius: 4px;
+    width: 244px;
+}
+
+.fadeOut {
+    opacity: 0;
+}
+
+.warningContent {
+    display: flex;
+    justify-content: space-between;
+    align-items: start;
+    gap: 6px;
+    color: var(--dark-theme-primary-color);
+}
+
+.closeButton {
+    background: none;
+    padding: 2px 0px;
+    font-size: 18px;
+    border: none;
+    color: var(--dark-theme-primary-color);
+    cursor: pointer;
+}

--- a/src/components/SmallScreenWarning/style.css
+++ b/src/components/SmallScreenWarning/style.css
@@ -1,4 +1,4 @@
-.warningContainer {
+.warning-container {
     position: absolute;
     top: var(--header-height);
     transform: translateX(-50%);
@@ -14,11 +14,11 @@
     width: 244px;
 }
 
-.fadeOut {
+.fade-out {
     opacity: 0;
 }
 
-.warningContent {
+.warning-content {
     display: flex;
     justify-content: space-between;
     align-items: start;
@@ -26,7 +26,7 @@
     color: var(--dark-theme-primary-color);
 }
 
-.closeButton {
+.close-button {
     background: none;
     padding: 2px 0px;
     font-size: 18px;

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -52,6 +52,7 @@ import { EMBED_PATHNAME, TUTORIAL_PATHNAME } from "../../routes";
 import ErrorNotification from "../../components/ErrorNotification";
 import { ExitFullScreen, FullScreen } from "../../components/Icons";
 import ViewportButton from "../../components/ViewportButton";
+import SmallScreenWarning from "../../components/SmallScreenWarning";
 import {
     SCALE_BAR_MIN_WIDTH,
     CONTROLS_MIN_HEIGHT,
@@ -181,18 +182,6 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                         or choose OK to continue anyway.
                     </p>
                 ),
-            });
-        }
-        // disable small screen warning on embed page
-        const location = window.location;
-        if (
-            window.matchMedia(MOBILE_CUTOFF).matches &&
-            location.pathname !== EMBED_PATHNAME
-        ) {
-            Modal.warning({
-                title: "Small screens are not supported",
-                content:
-                    "The Simularium Viewer does not support small screens at this time. Please use a larger screen for the best experience.",
             });
         }
         const current = this.centerContent.current;
@@ -513,6 +502,10 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             this.embedDisplaySettings;
         return (
             <div ref={this.centerContent} className={styles.container}>
+                {window.matchMedia(MOBILE_CUTOFF).matches &&
+                    location.pathname !== EMBED_PATHNAME && (
+                        <SmallScreenWarning />
+                    )}
                 <SimulariumViewer
                     height={this.state.height}
                     width={this.state.width}
@@ -604,9 +597,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                         )}
                     </div>
                 )}
-
                 {showScaleBar && <ScaleBar label={scaleBarLabel} />}
-
                 <CameraControls
                     resetCamera={simulariumController.resetCamera}
                     zoomIn={simulariumController.zoomIn}


### PR DESCRIPTION
Time estimate or Size
=======
_small_

Problem
=======
Part of ongoing home page redesign. Small screen modal is replaced with smaller redesigned warning that automatically fades out after a pause.

[design](https://www.figma.com/design/u4lZYuVwbsFpzBikgwAVRb/Master-components-Simularium?node-id=1360-1657&t=NDg3kXL42Xcb0kzk-1)

During fade:
<img width="489" alt="Screenshot 2025-03-26 at 4 43 25 PM" src="https://github.com/user-attachments/assets/a980761e-a7e8-4f02-b1fe-ca13def8f527" />
