### PR TITLE
fix color issues on cookie settings link in footer

### DIFF
--- a/src/components/Footer/style.css
+++ b/src/components/Footer/style.css
@@ -25,11 +25,12 @@
     font-weight: 200;
     font-size: 14px;
     color: var(--footer-link);
+    background-color: transparent;
     border: none;
     padding: 0;
 }
 
 .container :global(#ot-sdk-btn.ot-sdk-show-settings):hover, :global(#ot-sdk-btn.ot-sdk-show-settings):active, :global(#ot-sdk-btn.ot-sdk-show-settings):focus {
-    color: var(--footer-link);
+    color: var(--footer-link-active);
     background-color: transparent;
 }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -27,6 +27,7 @@
     --baby-purple: #b59ff6;
     --allen-purple: #8d87aa;
     --blue: #0094ff;
+    --light-blue: #52c2ff;
     --baby-purple-two: #dccfff;
     --medium-gray: #aeaeae;
     --dark-blue-gray: #69738a;
@@ -37,6 +38,8 @@
     --footer-bg: var(--dark-three);
     --footer-text: var(--warm-gray);
     --footer-text-border-bottom: var(--grayish-brown);
+    --footer-link: var(--blue);
+    --footer-link-active: var(--light-blue);
     --color-picker-tooltip: var(--dark-blue-gray);
     --cancel-icon-color: var(--brick-red);
     /* Dark theme */


### PR DESCRIPTION
Time estimate or Size
=======
_x-small_

Problem
=======
The cookie settings link started showing a green background and wrong text colors.



Solution
========
What I/we did to solve this problem
<img width="157" alt="Screenshot 2025-05-27 at 9 50 55 AM" src="https://github.com/user-attachments/assets/7e411a7e-809e-445e-86c3-5a58f25394dc" />

<img width="256" alt="Screenshot 2025-05-27 at 9 51 48 AM" src="https://github.com/user-attachments/assets/ab8c1488-88dc-4b53-a9a0-36d0d50b9573" />


* Bug fix (non-breaking change which fixes an issue)
