### PR TITLE
fix: link hover state on homepage

### DIFF
--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -46,8 +46,8 @@ const LandingPage = (): JSX.Element => {
                     </Link>
 
                     <Link
-                        to={ABOUT_PATHNAME}
                         className={styles.borderedContent}
+                        to={ABOUT_PATHNAME}
                     >
                         <div className={styles.borderedContentIcon}>{Read}</div>
                         <div className={styles.borderedContentInner}>

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -44,15 +44,19 @@ const LandingPage = (): JSX.Element => {
                             </p>
                         </div>
                     </Link>
-                    <div className={styles.borderedContent}>
+
+                    <Link
+                        to={ABOUT_PATHNAME}
+                        className={styles.borderedContent}
+                    >
                         <div className={styles.borderedContentIcon}>{Read}</div>
                         <div className={styles.borderedContentInner}>
-                            <Link to={ABOUT_PATHNAME}>
-                                <p>About Simularium</p>
-                            </Link>
-                            <p>Read more about Simularium and future plans</p>
+                            <p>About Simularium</p>
+                            <p className={styles.defaultTextColor}>
+                                Read more about Simularium and future plans
+                            </p>
                         </div>
-                    </div>
+                    </Link>
                 </div>
             </ContentPagePanel>
             <ContentPagePanel isDark={true} isWide={true}>


### PR DESCRIPTION
Time estimate or Size
=======
_x-small_

Problem
=======
The second of the two buttons in this container was wrapped wrong, so the hover styling wasn't applying to the whole component. I just made it match the one before in the container, which was working correctly.

<img width="1031" alt="Screenshot 2025-05-27 at 10 04 12 AM" src="https://github.com/user-attachments/assets/21c361a0-2031-4064-a7ca-2bea3debc1e7" />


* Bug fix (non-breaking change which fixes an issue)
