### PR TITLE
adjust bottom padding on homepage cards

### DIFF
--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -5,7 +5,7 @@
     flex-direction: column;
     filter: drop-shadow(2px 2px 10px black);
     gap: 10px;
-    padding: 16px 20px;
+    padding: 16px 20px 20px;
     overflow: hidden;
     width: 400px;
 }

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -7,7 +7,7 @@
     gap: 10px;
     padding: 16px 20px 20px;
     overflow: hidden;
-    width: 400px;
+    width: 342px;
 }
 
 .card.card-closed {


### PR DESCRIPTION
Time estimate or Size
=======
_small_

Problem
=======
homepage card with was too wide, and although padding seemed to match design spec it looked wrong, needed to add some bottom padding

Design:
<img width="127" alt="Screenshot 2025-05-27 at 10 12 28 AM" src="https://github.com/user-attachments/assets/8df6efd3-2ef5-4d66-adaf-92a9eea5a31d" />

Current:
<img width="121" alt="Screenshot 2025-05-27 at 10 13 02 AM" src="https://github.com/user-attachments/assets/9bd6d953-7be8-44b8-a179-1499e75d4a84" />

Fix:
<img width="117" alt="Screenshot 2025-05-27 at 10 13 44 AM" src="https://github.com/user-attachments/assets/c17651c8-3c62-467f-9802-bb9f47979661" />


Solution
========

* Bug fix (non-breaking change which fixes an issue)
