### PR TITLE
enable drag and drop on load file modal is open

### DIFF
--- a/src/components/CustomModal/index.tsx
+++ b/src/components/CustomModal/index.tsx
@@ -19,7 +19,7 @@ interface CustomModalProps extends Omit<ModalProps, OmittedProps> {
     titleText?: string;
     footerButtons?: React.ReactNode;
     divider?: boolean;
-    wrapProps?: Record<string, unknown>;
+    wrapProps?: { onDragOver: (e: DragEvent) => void };
     wrapClassName?: string;
 }
 

--- a/src/components/CustomModal/index.tsx
+++ b/src/components/CustomModal/index.tsx
@@ -19,6 +19,8 @@ interface CustomModalProps extends Omit<ModalProps, OmittedProps> {
     titleText?: string;
     footerButtons?: React.ReactNode;
     divider?: boolean;
+    wrapProps?: Record<string, unknown>;
+    wrapClassName?: string;
 }
 
 /** Wrapper to keep styling of modals consistent:
@@ -31,6 +33,8 @@ const CustomModal: React.FC<CustomModalProps> = ({
     titleText,
     footerButtons,
     divider,
+    wrapProps,
+    wrapClassName,
     ...props
 }) => {
     const title = (
@@ -66,6 +70,8 @@ const CustomModal: React.FC<CustomModalProps> = ({
             footer={footer}
             open
             centered
+            wrapClassName={wrapClassName}
+            wrapProps={wrapProps}
         />
     );
 };

--- a/src/components/FileUploadModal/index.tsx
+++ b/src/components/FileUploadModal/index.tsx
@@ -12,7 +12,6 @@ import {
     SetErrorAction,
     SetViewerStatusAction,
 } from "../../state/viewer/types";
-import { resetDragOverViewer } from "../../state/viewer/actions";
 import { ButtonClass } from "../../constants/interfaces";
 
 import CustomModal from "../CustomModal";
@@ -60,16 +59,13 @@ const FileUploadModal: React.FC<FileUploadModalProps> = ({
     useEffect(() => {
         if (!fileIsDraggedOverViewer) return;
 
-        const handleWindowDrop = (e: DragEvent) => {
-            e.preventDefault();
-            if (e.dataTransfer?.types.includes("Files")) {
-                closeModal();
-            }
+        const handleWindowDrop = () => {
+            closeModal();
         };
 
         window.addEventListener("drop", handleWindowDrop);
         return () => window.removeEventListener("drop", handleWindowDrop);
-    }, [fileIsDraggedOverViewer, closeModal, resetDragOverViewer]);
+    }, [fileIsDraggedOverViewer]);
 
     const fileDragClass = fileIsDraggedOverViewer
         ? styles.fileDragged
@@ -148,12 +144,7 @@ const FileUploadModal: React.FC<FileUploadModalProps> = ({
             width={525}
             wrapClassName={fileDragClass}
             wrapProps={{
-                onDragOver: (e: DragEvent) => {
-                    if (e.dataTransfer?.types.includes("Files")) {
-                        e.preventDefault();
-                        handleDragOver(e);
-                    }
-                },
+                onDragOver: (e: DragEvent) => handleDragOver(e),
             }}
         >
             <Tabs

--- a/src/components/FileUploadModal/style.css
+++ b/src/components/FileUploadModal/style.css
@@ -33,3 +33,11 @@
 .upload-modal :global(.ant-tabs .ant-tabs-tab-active) {
     font-weight: 400;
 }
+
+.file-dragged:global(.ant-modal-wrap) {
+    pointer-events: none;
+}
+
+.file-dragged :global(.ant-modal-content) {
+    pointer-events: none;
+}

--- a/src/components/LoadFileMenu/index.tsx
+++ b/src/components/LoadFileMenu/index.tsx
@@ -35,6 +35,8 @@ interface LoadFileMenuProps {
     setError: ActionCreator<SetErrorAction>;
     conversionStatus: ConversionStatus;
     setConversionStatus: ActionCreator<SetConversionStatusAction>;
+    fileIsDraggedOverViewer: boolean;
+    handleDragOver: (e: DragEvent) => void;
 }
 
 const LoadFileMenu = ({
@@ -46,6 +48,8 @@ const LoadFileMenu = ({
     setError,
     conversionStatus,
     setConversionStatus,
+    fileIsDraggedOverViewer,
+    handleDragOver,
 }: LoadFileMenuProps): JSX.Element => {
     const [isModalVisible, setIsModalVisible] = useState(false);
     const location = useLocation();
@@ -142,6 +146,8 @@ const LoadFileMenu = ({
                     loadLocalFile={loadLocalFile}
                     setViewerStatus={setViewerStatus}
                     setError={setError}
+                    handleDragOver={handleDragOver}
+                    fileIsDraggedOverViewer={fileIsDraggedOverViewer}
                 />
             )}
         </>

--- a/src/components/ViewerOverlayTarget/style.css
+++ b/src/components/ViewerOverlayTarget/style.css
@@ -2,7 +2,7 @@
     position: absolute;
     height: 100%;
     width: 100%;
-    z-index: 300;
+    z-index: 1001;
     background-color: rgba(181, 159, 246, 0.7);
 }
 

--- a/src/containers/AppHeader/index.tsx
+++ b/src/containers/AppHeader/index.tsx
@@ -24,6 +24,7 @@ import viewerStateBranch from "../../state/viewer";
 import {
     SetViewerStatusAction,
     SetErrorAction,
+    DragOverViewerAction,
 } from "../../state/viewer/types";
 import { ButtonClass } from "../../constants/interfaces";
 import ShareTrajectoryButton from "../../components/ShareTrajectoryButton";
@@ -43,6 +44,8 @@ interface AppHeaderProps {
     setError: ActionCreator<SetErrorAction>;
     conversionStatus: ConversionStatus;
     setConversionStatus: ActionCreator<SetConversionStatusAction>;
+    fileIsDraggedOverViewer: boolean;
+    dragOverViewer: ActionCreator<DragOverViewerAction>;
 }
 
 const AppHeader: React.FC<AppHeaderProps> = ({
@@ -56,6 +59,8 @@ const AppHeader: React.FC<AppHeaderProps> = ({
     isNetworkedFile,
     conversionStatus,
     setConversionStatus,
+    fileIsDraggedOverViewer,
+    dragOverViewer,
 }) => {
     const history = useHistory();
 
@@ -113,6 +118,8 @@ const AppHeader: React.FC<AppHeaderProps> = ({
                     setError={setError}
                     conversionStatus={conversionStatus}
                     setConversionStatus={setConversionStatus}
+                    handleDragOver={dragOverViewer}
+                    fileIsDraggedOverViewer={fileIsDraggedOverViewer}
                 />
                 <HelpMenu />
             </div>
@@ -129,6 +136,8 @@ function mapStateToProps(state: State) {
             trajectoryStateBranch.selectors.getIsNetworkedFile(state),
         conversionStatus:
             trajectoryStateBranch.selectors.getConversionStatus(state),
+        fileIsDraggedOverViewer:
+            viewerStateBranch.selectors.getFileDraggedOver(state),
     };
 }
 
@@ -140,6 +149,7 @@ const dispatchToPropsMap = {
     setViewerStatus: viewerStateBranch.actions.setStatus,
     setError: viewerStateBranch.actions.setError,
     setConversionStatus: trajectoryStateBranch.actions.setConversionStatus,
+    dragOverViewer: viewerStateBranch.actions.dragOverViewer,
 };
 
 export default connect(mapStateToProps, dispatchToPropsMap)(AppHeader);


### PR DESCRIPTION
Time estimate or Size
=======
_small_

Problem
=======
Advances #613 
UX requested: Enable drag and drop when the “Choose a Simularium file to load” modal is shown

Solution
========
Use existing redux state to prevent pointer events on modal and wrap when file is dragged over, renders overlay and allows drop.

Use a window event listener to close modal on drop (can't use wrap props when pointer events are disabled).

* New feature (non-breaking change which adds functionality)